### PR TITLE
vcnc-rest: list all grid job names capability

### DIFF
--- a/vcnc-rest/api/swagger.yaml
+++ b/vcnc-rest/api/swagger.yaml
@@ -97,7 +97,21 @@ paths:
   ##
   ##  Grid computing support
   ##
-  /grid/jobs/{job_id}:
+  /grid/jobs:
+    get:
+      summary: Retrieves information about all jobs
+      operationId: gridJobList
+      tags:
+        - "Grid API"
+      responses:
+        '200':
+          description: Request processed.  See response body.
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+
+  /grid/job/{job_id}:
     post:
       summary: Creates a new resource describing a job with the specified id.
       operationId: gridJobPost
@@ -168,129 +182,6 @@ paths:
           description: unexpected error
           schema:
             $ref: '#/definitions/Error'
-  ##
-  ##  vCNC - vtrq
-  ##
-    post:
-      summary: Creates a new vTRQ resource and assigns the vTRQ ID.
-      operationId: vcncVtrqCreate
-      tags:
-        - "Admin API"
-      parameters:
-        - in: body
-          name: body
-          description: "Information about a host machine."
-          required: true
-          schema:
-            $ref: '#/definitions/Host'
-        - in: header
-          name: "Authorization"
-          description: JWT session token
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Request processed.  See response body.
-        default:
-          description: unexpected error
-          schema:
-            $ref: '#/definitions/Error'
-
-    put:
-      summary: Updates a vTRQ entry.
-      operationId: vcncVtrqUpdate
-      tags:
-        - "Admin API"
-      parameters:
-        - in: path
-          name: vtrq_id
-          description: ID of vTRQ
-          required: true
-          type: integer
-          format: int64
-          minimum: 0
-          maximum: 1073741823
-        - in: body
-          name: body
-          description: "Information about a host machine."
-          required: true
-          schema:
-            $ref: '#/definitions/Host'
-        - in: header
-          name: "Authorization"
-          description: JWT session token
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Request processed.  See response body.
-        default:
-          description: unexpected error
-          schema:
-            $ref: '#/definitions/Error'
-
-    get:
-      summary: Retrieves data associated with a vTRQ.
-      operationId: vcncVtrqGet
-      tags:
-        - "Admin API"
-      produces:
-        - application/json
-      parameters:
-        - in: path
-          name: vtrq_id
-          description: ID of vTRQ
-          required: true
-          type: integer
-          format: int64
-          minimum: 0
-          maximum: 1073741823
-        - in: header
-          name: "Authorization"
-          description: JWT session token
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Request processed.  See response body.
-          schema:
-            $ref: '#/definitions/Host'
-        default:
-          description: unexpected error
-          schema:
-            $ref: '#/definitions/Error'
-
-    delete:
-      summary: Deletes a vTRQ entry.
-      operationId: vcncVtrqDelete
-      tags:
-        - "Admin API"
-      parameters:
-        - in: path
-          name: vtrq_id
-          description: ID of vTRQ
-          required: true
-          type: integer
-          format: int64
-          minimum: 0
-          maximum: 1073741823
-        - in: header
-          name: "Authorization"
-          description: JWT session token
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Request processed.  See response body.
-        '400':
-          description: Ill-formed or invalid request.
-          schema:
-            $ref: '#/definitions/Error'
-        default:
-          description: unexpected error
-          schema:
-            $ref: '#/definitions/Error'
-
   ##
   ##  vCNC - users
   ##
@@ -1477,54 +1368,6 @@ definitions:
           - EREMOTEIO
       message:
         type: string
-
-#  PSpaceNode:
-#    type: object
-#    properties:
-#      N:
-#        type: string
-#      C:
-#        type: array
-#        minItems: 0
-#        items:
-#          $ref: '#/definitions/PSpaceNode'
-#    required:
-#      - N
-#    additionalProperties: false
-#
-#  PSpace:
-#    type: object
-#    properties:
-#      P:
-#        type: string
-#      S:
-#        $ref: '#/definitions/PSpaceNode'
-#    required:
-#      - P
-#      - S
-#    additionalProperties: false
-
-  Host:
-    type: object
-    properties:
-      hname:
-        type: string
-      vtrq_id:
-        type: integer
-      port:
-        type: string
-      transport:
-        type: string
-        default: tcp
-        enum:
-          - tcp
-          - sctp
-    required:
-      - hname
-      - vtrq_id
-      - port
-      - transport
-    additionalProperties: false
 
   SourceDestinationPath:
     properties:

--- a/vcnc-rest/lib/grid.js
+++ b/vcnc-rest/lib/grid.js
@@ -71,6 +71,16 @@ function getJob(id) {
 }
 
 /**
+ *  Fetches names of all grid jobs
+ *
+ *  @param {string} id The job identifier.
+ *  @return {promise} A promise resolving to information about the jobs.
+ */
+function getJobs() {
+  return r.table(tableName).pluck('id').run(cnxtn);
+}
+
+/**
  *  Deletes the specified grid job.
  *
  *  @param {string} id The job identifier.
@@ -84,5 +94,6 @@ module.exports = {
   init,
   createJob,
   getJob,
+  getJobs,
   deleteJob,
 };

--- a/vcnc-rest/routes/v1.js
+++ b/vcnc-rest/routes/v1.js
@@ -58,9 +58,54 @@ function adapter(fromRpc, onSuccess, onFailure) {
  */
 module.exports = (app) => {
   //
+  //  Returns the collection of grid job records
+  //
+  app.get('/grid/jobs', (req, res) => {
+    const job_id = req.pathParams.job_id;
+    fulfill202(
+      req,
+      res,
+      (cb) => {
+        latency()
+        .then(()=> {
+          return grid.getJobs();
+        })
+        .then(result => {
+          return result.toArray()
+        })
+        .then(result => {
+          if (result) {
+            cb(adapter({
+              http_status: 200,
+              error_sym: 'OK',
+              error_description_brief: 'Request processed',
+            },{
+              job_names: result.map(e => e.id)
+            }));
+          } else {
+            // Something went wrong
+            cb(adapter({
+              http_status: 500,
+              error_sym: 'EREMOTEIO',
+              error_description_brief: 'Server Error',
+            }))
+          }
+        })
+        .catch(err => {
+          //  Error from database
+          cb(adapter({
+            http_status: 500,
+            error_sym: 'EPROTO',
+            error_description_brief: 'Server Error',
+          }, {}, {server_msg: err.toString()}));
+        });
+      });
+  });
+
+  //
   //  Creates a grid job record
   //
-  app.post('/grid/jobs/:job_id', (req, res) => {
+  app.post('/grid/job/:job_id', (req, res) => {
     fulfill202(
       req,
       res,
@@ -113,7 +158,7 @@ module.exports = (app) => {
   //
   //  Returns a grid job record
   //
-  app.get('/grid/jobs/:job_id', (req, res) => {
+  app.get('/grid/job/:job_id', (req, res) => {
     const job_id = req.pathParams.job_id;
     fulfill202(
       req,
@@ -124,6 +169,7 @@ module.exports = (app) => {
           return grid.getJob(job_id);
         })
         .then(result => {
+          console.log(result)
           if (result) {
             cb(adapter({
               http_status: 200,
@@ -154,7 +200,7 @@ module.exports = (app) => {
   //
   //  Deletes a grid job record
   //
-  app.delete('/grid/jobs/:job_id', (req, res) => {
+  app.delete('/grid/job/:job_id', (req, res) => {
     const job_id = req.pathParams.job_id;
     fulfill202(
       req,


### PR DESCRIPTION
I had to rename /grid/jobs/{jobid} to /grid/job/{jobid}.  That's because I needed GET /grid/jobs to retrieve the entire collection.

I plan to migrate to this convention for the other endpoints.  Someday.

Also deleted a bunch of unused endpoints in swagger.yaml