### PR TITLE
'vclc grid job jobname' non-zero trqid fail

### DIFF
--- a/api-python/ChangeLog
+++ b/api-python/ChangeLog
@@ -1,3 +1,173 @@
 Release 3.4.2
 
 	Added 'vtrq_id' to the 'grid job' POST request body.
+
+	Remove supurious output from 'vsh'
+
+Release 3.4.1
+
+	vclc uses new-style workspace specifications. Set VELSTOR_VCLC_COMPAT=1
+	to get old-style.
+
+	New 'vclc grid list' command.
+
+	New 'vgrid --list' option.
+
+Release 3.4.0
+
+	The 'grid jobs' clients: vsh and vgrid
+
+	vclc extended to encompass the 'grid jobs' REST operations.
+
+	Automatically unmount vsh fuse mounts.
+
+Release 3.3.3
+
+	Changed the default vCNC port to its new value.
+
+	<B4998> Fixed exception thrown when trqid or vcnc host is
+	unspecified.
+
+Release 3.3.2
+
+	Fixed the ETIME message from vclc ns mkdir ...
+
+Release 3.3.1
+
+	<FRQU-119> Corrected description of --overwrite. Again.
+
+Release 3.3.0
+
+	Pretty-print JSON output
+
+	<FRQU-119> Corrected description of --overwrite.
+
+Release 3.2.6
+
+	API is 202/fulfill asynchronous protocol aware.
+
+	vCLC is fully synchronous against the vCNC.
+
+Release 3.2.5
+
+	Brought codebase into PEP8 conformance.
+
+Release 3.2.4
+
+	<FRQU-103> Improved responses when the value of --vcnc is an
+	existing web server or a non-existent machine/port.
+
+	Syntax errors in 'vclc ws set' JSON are reported by line and
+	column.
+
+Release 3.2.3
+
+	<B9430> Fixed exception thrown when 'ns copy' succeeded.
+
+	<FRQU-93> fixed the stack trace triggered by CTL-C
+
+	<FRQU-89> 'ws set' invalid JSON prints a descriptive error message
+	with line and column references.
+
+Release 3.2.2
+	Removed debug logging that was polluting stdout.
+
+	Added a --debug option that logs HTTP activity to stderr.
+
+Release 3.2.1
+	<B5413> Fixed the continual ENOENT in 'vp find'.
+
+	Re-structured the install directory tree so that the vclc release
+	can be copied on top of a velstor release for unified packaging.
+
+	Fixed the missing build number in 'vclc --version'
+
+Release 3.2.0
+	Changed the syntax of 'vp find' to make all the search criteria
+	optional.  This matches the way the vCNC REST API works.
+
+Release 3.1.1
+	Changed the default port to 5500 from 9080
+
+	Automated test that exercises every command except 'shutdown'
+
+	In the help, mention that 'vp delete' is a future feature.
+
+	Fixed a cut and paste error in 'ns rm' help.
+
+	Fixed bugs in 'ns mkdir'
+
+Release 3.1.0
+	Re-tagged for Xilinx release candidate.
+
+Release 3.0.1
+	Fixed bugs created due to refactoring errors.
+
+Release 3.0.0
+	Reflects VelStor branding all the way down.  Must be used against
+	a velstorized vCNC
+
+Release 2.3.0
+	Added vp commands 'clc vp get', 'clc vp find' and 'clc vp delete'
+
+Release 2.2.1
+
+	Fixed various crashes due to recent code refactoring.
+
+	Make the --json flag toggle a boolean.  Has no effect today;
+	scripts should specify --json for forward compatibility.
+
+	Increase the timeout on potentially long operations to 24
+	hours. This is a temporary measure until true HTPP asynchronous
+	handling can be implemented.
+
+	Increse the timeout on 'ns ls' to 5s from 1s.
+
+	CLC output is true JSON rather than a Python dict representation.
+
+Release 2.2.0:
+
+	Correct the help message for 'clc ns ls' to indicate that only
+	directories can be listed.
+
+	Suggest checking environment and command line switches if clc
+	fails to connect to the default CNC host:port value.  In any case,
+	present a friendlier message when the CNC doesn't respond at all.
+
+	The 'ns ls' command has a short (1 sec) connection timeout.
+	Eventually, all the commands will have a configurable timeout, but
+	in the meantime 'clc ns ls /' can be used for testing.
+
+	Fix <B9705>: exception on valid meta-data copy.
+
+Release 2.1.0:
+	Recursive delete option for namespace deletes.
+
+	Additional short-form options for most operations.
+
+Release 2.0.0:
+	Handle all corner cases for uniform JSON output.
+
+	Correctly return $? exit code for metadata copy
+
+Release 1.2.0:
+	Support the --parents option for mkdir
+
+Release 1.0.2:
+	--cnc default value is now 'cnc:9080'.
+
+	--trqid default value is now '0'
+
+	Gracefully handle failure to reach the specified CNC server.
+
+	Write informational messages and unstructured error messages to
+	stderr.  stdout is reserved for automated parsing.
+
+	--help provides information about option default values and
+	environment variables.
+
+Release 1.0.1:
+	Rebuilt with CPython bundled
+
+Release 1.0.0:
+	Initial release.

--- a/api-python/ChangeLog
+++ b/api-python/ChangeLog
@@ -1,0 +1,3 @@
+Release 3.4.2
+
+	Added 'vtrq_id' to the 'grid job' POST request body.

--- a/api-python/velstor/api/grid.py
+++ b/api-python/velstor/api/grid.py
@@ -44,12 +44,13 @@ def delete(session, jobid):
     return fulfill202(session, r)
 
 
-def post(session, jobid, workspace_name):
+def post(session, jobid, vtrq_id, workspace_name):
     """Posts information about a grid job.
 
     Args:
         session (:class:`~velstor.api.session.Session`): Provides security information.
         jobid (str): The job's identifying string.
+        vtrq_id (int): The vTRQ of the worksapce name.
         workspace_name (str): The PeerCache workspace employed by the job.
 
     Returns:
@@ -59,7 +60,11 @@ def post(session, jobid, workspace_name):
     url = '/'.join([session.base_url()
                     , 'grid/job'
                     , urlencode(jobid)])
-    r = requests.post(url, json={'workspace_name': workspace_name})
+    r = requests.post(url
+                      , json={
+                          'workspace_name': workspace_name
+                          , 'vtrq_id': vtrq_id
+                      })
     return fulfill202(session, r)
 
 def list(session):

--- a/api-python/velstor/vclc/vclc_parser.py
+++ b/api-python/velstor/vclc/vclc_parser.py
@@ -90,7 +90,7 @@ def _configure_grid(grid_subparsers, handler):
     parser_grid_post.set_defaults(
         action=handler.action
         , api_func=grid.post
-        , api_args=['jobid', 'wkspc_name'])
+        , api_args=['jobid', 'vtrqid', 'wkspc_name'])
     #
     #  .. grid get job
     parser_grid_get = grid_subparsers.add_parser(

--- a/api-python/velstor/vsh/__main__.py
+++ b/api-python/velstor/vsh/__main__.py
@@ -160,5 +160,6 @@ def worker(session, args):
 
 if __name__ == "__main__":
     (exit_code, response) = main()
-    print(json.dumps(response, sort_keys=True, indent=2))
+    if response:
+        print(json.dumps(response, sort_keys=True, indent=2))
     sys.exit(127 if (exit_code > 127) else exit_code)

--- a/api-python/version.json
+++ b/api-python/version.json
@@ -1,5 +1,5 @@
 {
   "comment": "The vclc version nuber is set here, in this file. The build number is automatically set during the build. Scripts require the four zeros to be literally present."
-  , "version": "3.4.1"
+  , "version": "3.4.2"
   , "build": "0000"
 }

--- a/vcnc-rest/ChangeLog
+++ b/vcnc-rest/ChangeLog
@@ -1,3 +1,13 @@
+Release 3.5.3
+
+    Fix 'grid job POST' stuck on vTRQ ID 0
+
+    Fix supurious vsh output
+
+Release 3.5.2
+
+    Hotfix for job_spec/JobSpec issue
+
 Release 3.5.1
 
     Refactored serve both v1 and v2 API simultaneously on the same port.

--- a/vcnc-rest/api/v1api.yaml
+++ b/vcnc-rest/api/v1api.yaml
@@ -130,6 +130,13 @@ paths:
           schema:
             type: object
             properties:
+              vtrq_id:
+                description: ID of the vTRQ performing this operation.
+                type: integer
+                format: int64
+                minimum: 0
+                maximum: 1073741823
+                default: 0
               workspace_name:
                 type: string
             required:

--- a/vcnc-rest/api/v2api.yaml
+++ b/vcnc-rest/api/v2api.yaml
@@ -125,6 +125,13 @@ paths:
           schema:
             type: object
             properties:
+              vtrq_id:
+                description: ID of the vTRQ performing this operation.
+                type: integer
+                format: int64
+                minimum: 0
+                maximum: 1073741823
+                default: 0
               workspace_name:
                 type: string
             required:

--- a/vcnc-rest/configure.ac
+++ b/vcnc-rest/configure.ac
@@ -5,7 +5,7 @@
 #
 #	See the file 'COPYING' for license information.
 #
-AC_INIT(vCNC, 3.5.1, nick@icmanage.com)
+AC_INIT(vCNC, 3.5.3, nick@icmanage.com)
 AC_PREFIX_DEFAULT(/opt/vcnc)
 #
 AM_CONFIG_HEADER(config.h)

--- a/vcnc-rest/installer/vcnc-rethinkdb.service
+++ b/vcnc-rest/installer/vcnc-rethinkdb.service
@@ -1,0 +1,25 @@
+;
+;  Copyright (c) IC Manage, Inc.  All rights reserved.
+;
+;  See also http://www.freedesktop.org/software/systemd/man/systemd.unit.html
+;
+;  On machine 'cnc', we are running one reThinkDB instance for all of the vcnc 
+;  instances.  They currently don't collide even if they use the same reThinkDB
+;  prefix.
+;
+[Unit]
+Description=reThinkDB for VelStor vCNC
+
+[Service]
+Type=simple
+Environment=LD_LIBRARY_PATH=/opt/vcnc-saluki/current/lib64
+ExecStart=/opt/vcnc-saluki/current/bin/rethinkdb --config-file /opt/vcnc-saluki/current/share/vcnc/vcnc-rest/config/vcnc-rethinkdb.conf
+Restart=always
+StandardOutput=syslog+console
+StandardError=syslog+console
+SyslogIdentifier=vcnc-rethinkdb
+User=root
+Group=root
+
+[Install]
+WantedBy=remote-fs.target

--- a/vcnc-rest/routes/v1.js
+++ b/vcnc-rest/routes/v1.js
@@ -61,26 +61,21 @@ module.exports = (app) => {
   //  Returns the collection of grid job records
   //
   app.get('/grid/jobs', (req, res) => {
-    const job_id = req.pathParams.job_id;
     fulfill202(
       req,
       res,
       (cb) => {
         latency()
-        .then(()=> {
-          return grid.getJobs();
-        })
-        .then(result => {
-          return result.toArray()
-        })
+        .then(() => grid.getJobs())
+        .then(result => result.toArray())
         .then(result => {
           if (result) {
             cb(adapter({
               http_status: 200,
               error_sym: 'OK',
               error_description_brief: 'Request processed',
-            },{
-              job_names: result.map(e => e.id)
+            }, {
+              job_names: result.map(e => e.id),
             }));
           } else {
             // Something went wrong
@@ -88,7 +83,7 @@ module.exports = (app) => {
               http_status: 500,
               error_sym: 'EREMOTEIO',
               error_description_brief: 'Server Error',
-            }))
+            }));
           }
         })
         .catch(err => {
@@ -97,7 +92,7 @@ module.exports = (app) => {
             http_status: 500,
             error_sym: 'EPROTO',
             error_description_brief: 'Server Error',
-          }, {}, {server_msg: err.toString()}));
+          }, {}, { server_msg: err.toString() }));
         });
       });
   });
@@ -118,7 +113,7 @@ module.exports = (app) => {
           //  also store in the database.
           //
           cnctrqClient.workspace_get(
-            config.peercache.vtrq_id,
+            req.body.vtrq_id,
             req.body.workspace_name,
             (result) => {
               if (result.http_status === 200) {
@@ -159,7 +154,6 @@ module.exports = (app) => {
   //
   app.get('/grid/job/:job_id', (req, res) => {
     const jobId = req.pathParams.job_id;
-
     fulfill202(
       req,
       res,
@@ -167,7 +161,6 @@ module.exports = (app) => {
         latency()
         .then(() => grid.getJob(jobId))
         .then(result => {
-          console.log(result)
           if (result) {
             cb(adapter({
               http_status: 200,

--- a/vcnc-rest/routes/v2.js
+++ b/vcnc-rest/routes/v2.js
@@ -61,26 +61,21 @@ module.exports = (app) => {
   //  Returns the collection of grid job records
   //
   app.get('/grid/jobs', (req, res) => {
-    const job_id = req.pathParams.job_id;
     fulfill202(
       req,
       res,
       (cb) => {
         latency()
-        .then(()=> {
-          return grid.getJobs();
-        })
-        .then(result => {
-          return result.toArray()
-        })
+        .then(() => grid.getJobs())
+        .then(result => result.toArray())
         .then(result => {
           if (result) {
             cb(adapter({
               http_status: 200,
               error_sym: 'OK',
               error_description_brief: 'Request processed',
-            },{
-              job_names: result.map(e => e.id)
+            }, {
+              job_names: result.map(e => e.id),
             }));
           } else {
             // Something went wrong
@@ -88,7 +83,7 @@ module.exports = (app) => {
               http_status: 500,
               error_sym: 'EREMOTEIO',
               error_description_brief: 'Server Error',
-            }))
+            }));
           }
         })
         .catch(err => {
@@ -97,7 +92,7 @@ module.exports = (app) => {
             http_status: 500,
             error_sym: 'EPROTO',
             error_description_brief: 'Server Error',
-          }, {}, {server_msg: err.toString()}));
+          }, {}, { server_msg: err.toString() }));
         });
       });
   });
@@ -118,7 +113,7 @@ module.exports = (app) => {
           //  also store in the database.
           //
           cnctrqClient.workspace_get(
-            config.peercache.vtrq_id,
+            req.body.vtrq_id,
             req.body.workspace_name,
             (result) => {
               if (result.http_status === 200) {
@@ -167,7 +162,6 @@ module.exports = (app) => {
         latency()
         .then(() => grid.getJob(jobId))
         .then(result => {
-          console.log(result)
           if (result) {
             cb(adapter({
               http_status: 200,


### PR DESCRIPTION
Dave noticed that 'vclc grid job jobname' worked when the vtrq ID was zero but not when it was non-zero.

vcnc-rest was getting the vtrq_id from a fictitious config file entry.  JavaScript's type coercion, helpful to a fault, silently converted non-existence into zero. Hence, the bug only shows up for non-zero vtrq id.

The key is to notice that a *workspace name* isn't meaningful without a *vtrq_id*. The solution is to provide a 'vtrq_id' (which is known to the vclc and vgrid) in the request body of 'POST /grid/job/:jobid'

This request contains a few miscellaneous things: some files brought up to AirBnb JavaScript standards, removing a spurous output from vsh, and bringing the rethinkdb .service file into git.

