### PR TITLE
vcnc-rest: a new rethink.js module manages database schema revisions

### DIFF
--- a/vcnc-rest/ChangeLog
+++ b/vcnc-rest/ChangeLog
@@ -1,3 +1,11 @@
+Release 3.6.0
+
+    Record RethinkDB major/minor schema version history.
+
+    Recognize environment variables VELSTOR_VCNC_RETHINKDB_HOST and
+    VELSTOR_VCNC_RETHINKDB_DB. They override vcnc-config.yaml entries
+    rethinkdb.connection.host and rethinkdb.connection.db, respectively.
+
 Release 3.5.3
 
     Fix 'grid job POST' stuck on vTRQ ID 0

--- a/vcnc-rest/app.js
+++ b/vcnc-rest/app.js
@@ -19,6 +19,7 @@ const path = require('path');
 const http = require('http');
 const cors = require('cors');
 const grid = require('./lib/grid.js');
+const rethink = require('./lib/rethink.js');
 //
 //  Initialize the C++ extension
 //
@@ -266,7 +267,8 @@ module.exports = (() => {
   installErrorGenerator(app);
   installLogging(app);
   installStaticContent(app);
-  grid.init()
+  rethink.init()
+  .then(() => grid.init())
   .then(() => configureSwaggerMiddleware(app, 'api/v1api.json'))
   .then(() => configureSwaggerMiddleware(app, 'api/v2api.json'))
   .then(() => {

--- a/vcnc-rest/app.js
+++ b/vcnc-rest/app.js
@@ -278,6 +278,8 @@ module.exports = (() => {
   })
   .catch(err => {
     console.log(err); // eslint-disable-line
+    console.log('Exiting...'); // eslint-disable-line
+    process.exit(0);
   });
   //
   //  The web administration console is independent of all the above.

--- a/vcnc-rest/lib/configuration.js
+++ b/vcnc-rest/lib/configuration.js
@@ -15,6 +15,16 @@ console.log('INFO:   vcnc using configuration file', confPath); // eslint-disabl
 if ('VELSTOR_VCNC_PORT' in process.env) {
   conf.server.port = process.env.VELSTOR_VCNC_PORT;
 }
+//
+//  Get the RethinkDB host name/IP
+//  Get the RethinkDB database name
+//
+if ('VELSTOR_VCNC_RETHINKDB_HOST' in process.env) {
+  conf.rethinkdb.connection.host = process.env.VELSTOR_VCNC_RETHINKDB_HOST;
+}
+if ('VELSTOR_VCNC_RETHINKDB_DB' in process.env) {
+  conf.rethinkdb.connection.db = process.env.VELSTOR_VCNC_RETHINKDB_DB;
+}
 
 //
 //  Compute the default fulfillment URL.

--- a/vcnc-rest/lib/grid.js
+++ b/vcnc-rest/lib/grid.js
@@ -26,7 +26,7 @@ function init() {
   .then(lst => {
     //  Create the database if necessary.
     if (lst.length === 0) {
-      return r.dbCreate(dbName).run(cnxtn);
+      return Promise.reject(`grid.js: database ${dbName} does not exist`);
     }
     return Promise.resolve();
   })

--- a/vcnc-rest/lib/rethink.js
+++ b/vcnc-rest/lib/rethink.js
@@ -71,7 +71,7 @@ function init() {
       if (lst[0].schemaMinor === schemaMinor) {
         return Promise.resolve();
       }
-      if (list[0].schemaMinor > schemaMinor) {
+      if (lst[0].schemaMinor > schemaMinor) {
         //
         //  The database is newer than this code
         return Promise.reject(

--- a/vcnc-rest/lib/rethink.js
+++ b/vcnc-rest/lib/rethink.js
@@ -1,0 +1,89 @@
+/*
+ *    Copyright (C) 2017    IC Manage Inc.
+ *
+ *    See the file 'COPYING' for license information.
+ */
+'use strict'; // eslint-disable-line strict
+const config = require('./configuration.js');
+const r = require('rethinkdb');
+const dbName = config.rethinkdb.connection.db;
+const tableName = 'about';
+let cnxtn = null;
+
+const schemaMajor = 1;
+const schemaMinor = 0;
+
+function newAboutRow() {
+  return r.table(tableName).insert({
+    schemaMajor,
+    schemaMinor,
+    timestamp: r.now()
+  }).run(cnxtn);
+}
+
+/**
+ *  Initializes the rethinkdb module, creating a connection object
+ *  and creating the database if necessary.
+ *
+ *  Must be called before any other rethinkdb related module.
+ *
+ *  @return {promise} A promise fulfilled when the connection is ready.
+ */
+function init() {
+  if (!config.test.enable_grid_jobs) return Promise.resolve();
+  return r.connect(config.rethinkdb.connection)
+  .then(conn => {
+    cnxtn = conn;  // save the connection for later reuse
+    return r.dbList().filter(v => v.eq(dbName)).run(conn);
+  })
+  .then(lst => {
+    //  Create the database if necessary.
+    if (lst.length === 0) {
+      return r.dbCreate(dbName).run(cnxtn);
+    }
+    return Promise.resolve();
+  })
+  .then(() =>
+    //  Look for the table in the database
+    r.tableList().filter(v => v.eq(tableName)).run(cnxtn)
+  )
+  .then(lst => {
+    // Create the table if necessary.
+    if (lst.length === 0) {
+      return r.tableCreate(tableName).run(cnxtn);
+    }
+    return Promise.resolve();
+  })
+  .then(() => r.table(tableName).orderBy(r.desc('timestamp')).limit(1).run(cnxtn))
+  .then(lst => {
+    if (lst.length === 0) {
+      // Create the row
+      return newAboutRow();
+    } else {
+      //
+      //  Check the major rev number
+      if (lst[0].schemaMajor !== schemaMajor) {
+        return Promise.reject(
+          `rethink.js: db major rev ${lst[0].schemaMajor} does not match server rev ${schemaMajor}`);
+      }
+      //
+      //  Check the minor rev number
+      if (lst[0].schemaMinor === schemaMinor) {
+        return Promise.resolve();
+      }
+      if (list[0].schemaMinor > schemaMinor) {
+        //
+        //  The database is newer than this code
+        return Promise.reject(
+          `rethink.js: db minor rev ${lst[0].schemaMinor} newer than server rev ${schemaMinor}`);
+      }
+      //
+      //  We are a newer minor rev than this database.
+      return newAboutRow();
+    }
+  });
+}
+
+module.exports = {
+  init,
+};


### PR DESCRIPTION
Fulfills #7 

I used a shorter table name ('about' rather than 'about-this-database').  Also threw in some new environment variables for commonly-overridden configuration items.