### PR TITLE
vcnc-web: v2 REST API refinements: (1) ensure the distinction between…

### DIFF
--- a/vcnc-rest/api/v2api.yaml
+++ b/vcnc-rest/api/v2api.yaml
@@ -8,6 +8,11 @@
 #
 swagger: '2.0'
 
+#
+#  JSON structure:
+#    In response bodies, the returned data is packaged into a single key that is a sibling of 'error_sym'.
+#    Everywhere else, we prefer to avoid creating hierarchy.  Hierarchy complicates object manipulation in the browser.
+
 # Document metadata
 info:
   version: "2.0.0"
@@ -558,112 +563,6 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-  /vtrq/{vtrq_id}/namespace/{url_path}/consistency:
-    get:
-      summary: Retreives the consistency attribute of a vTRQ node.
-      operationId: vtrqNamespaceConsistencyGet
-      tags:
-        - "vTRQ Namespace"
-      parameters:
-        - in: path
-          name: vtrq_id
-          description: ID of the vTRQ performing this operation.
-          required: true
-          type: integer
-          format: int64
-          minimum: 0
-          maximum: 1073741823
-        - in: path
-          name: url_path
-          description: URL-encoded path in the vTRQ namespace.
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Request processed. See response body.
-          schema:
-            required:
-              - error_sym
-              - consistency
-            properties:
-              error_sym:
-                type: string
-                description: Symbolic error code value
-                default: OK
-                enum:
-                  - OK
-                  - EACCESS
-                  - ENOENT
-                  - ENOTDIR
-                  - ENAMETOOLONG
-                  - EEXIST
-                  - ENOSPC
-                  - EREMOTEIO
-              consistency:
-                $ref: '#/definitions/Consistency'
-            additionalProperties: false
-        default:
-          description: HTTP error
-          schema:
-            $ref: '#/definitions/Error'
-
-    post:
-      summary: Sets the consistency attribute of a vTRQ node.
-      operationId: vtrqNamespaceConsistencySet
-      tags:
-        - "vTRQ Namespace"
-      parameters:
-        - in: path
-          name: vtrq_id
-          description: ID of the vTRQ performing this operation.
-          required: true
-          type: integer
-          format: int64
-          minimum: 0
-          maximum: 1073741823
-        - in: path
-          name: url_path
-          description: URL-encoded path in the vTRQ namespace.
-          required: true
-          type: string
-        - in: body
-          name: body
-          description: "Additional parameters"
-          required: true
-          schema:
-            type: object
-            properties:
-              consistency:
-                $ref: '#/definitions/Consistency'
-            required:
-              - consistency
-            additionalProperties: false
-      responses:
-        '200':
-          description: Request processed. See response body.
-          schema:
-            required:
-              - error_sym
-            properties:
-              error_sym:
-                type: string
-                description: Symbolic error code value
-                default: OK
-                enum:
-                  - OK
-                  - EACCESS
-                  - ENOENT
-                  - ENOTDIR
-                  - ENAMETOOLONG
-                  - EEXIST
-                  - ENOSPC
-                  - EREMOTEIO
-            additionalProperties: false
-        default:
-          description: HTTP error
-          schema:
-            $ref: '#/definitions/Error'
-
   /vtrq/{vtrq_id}/namespace/{url_path}/mkdir:
     post:
       summary: Creates a directory at a namespace path.
@@ -783,11 +682,7 @@ paths:
           schema:
             required:
               - error_sym
-              - gid
-              - mount_point
-              - uid
-              - user
-              - workspace
+              - vp
             properties:
               error_sym:
                 type: string
@@ -797,26 +692,8 @@ paths:
                   - OK
                   - EACCESS
                   - EREMOTEIO
-              gid:
-                type: integer
-                description: Group ID of VP process.
-                example: 101
-              mount_point:
-                type: string
-                description: "Fully qualified path to the VP's mount point."
-                example: "/path/to/mount/point"
-              uid:
-                type: integer
-                description: User ID of VP process.
-                example: 101
-              user:
-                type: string
-                description: PeerCache hierarchical user name.
-                example: /marketing/sally
-              workspace:
-                type: string
-                description: Name of the PeerCache workspace.
-                example: /some/workspace/name
+              vp:
+                $ref: '#/definitions/VpInstance'
         default:
           description: HTTP error
           schema:
@@ -940,7 +817,7 @@ paths:
               - spec
             properties:
               spec:
-                $ref: '#/definitions/WorkspaceSpec'
+                $ref: '#/definitions/Workspace'
             additionalProperties: false
       responses:
         '200':
@@ -1022,7 +899,7 @@ paths:
             type: object
             required:
               - error_sym
-              - spec
+              - workspace
             properties:
               error_sym:
                 type: string
@@ -1033,8 +910,8 @@ paths:
                   - EACCES
                   - ENOENT
                   - EREMOTEIO
-              spec:
-                $ref: '#/definitions/WorkspaceSpec'
+              workspace:
+                $ref: '#/definitions/Workspace'
             additionalProperties: false
         default:
           description: HTTP error
@@ -1139,17 +1016,7 @@ paths:
           description: "Workspace Specification"
           required: true
           schema:
-            type: object
-            properties:
-              name:
-                type: string
-                example: workspace_a
-              spec:
-                $ref: '#/definitions/WorkspaceSpec'
-            required:
-              - name
-              - spec
-            additionalProperties: false
+            $ref: '#/definitions/Workspace'
       responses:
         '200':
           description: Request processed. See response body.
@@ -1285,14 +1152,6 @@ paths:
 #  Re-usable object definitions.
 #
 definitions:
-
-  Consistency:
-    type: string
-    description: Consistency semantics
-    default: eventual
-    enum:
-      - eventual
-      - immediate
 
   DeleteNodesRequest:
     type: object
@@ -1440,6 +1299,7 @@ definitions:
         $ref: '#/definitions/SourceDestinationErrorVector'
 
   NodeInfo:
+    description: Intentionally using 'name' rather than 'path', because this is used in a hierarchical context.
     type: object
     properties:
       name:
@@ -1618,9 +1478,12 @@ definitions:
       - vtrq_path
     additionalProperties: false
 
-  WorkspaceSpec:
+  Workspace:
     type: object
     properties:
+      name:
+        type: string
+        example: myWorkspace
       maps:
         type: array
         items:
@@ -1639,11 +1502,3 @@ definitions:
       - writeback
     additionalProperties: false
 
-  Workspace:
-    type: object
-    properties:
-      name:
-        type: string
-        example: /my/workspace
-      spec:
-        $ref: '#/definitions/WorkspaceSpec'


### PR DESCRIPTION
… 'name' and 'path' is maintained, (2) consistently make response bodies have two keys: 'error_sym' and a suitable name for the payload, (3) continue to convert response bodies to forms which unify the name with the rest of the entity.

Hey Yefim, please scrutinize this API to ensure it's consistent, complete, and correct.  Like always ;-)