### PR TITLE
vcnc-rest: v2 api - changed a key from 'spec' to 'workspace' to be mo…

### DIFF
--- a/vcnc-rest/api/v2api.yaml
+++ b/vcnc-rest/api/v2api.yaml
@@ -787,13 +787,7 @@ paths:
           description: "Workspace Specification"
           required: true
           schema:
-            type: object
-            required:
-              - spec
-            properties:
-              spec:
-                $ref: '#/definitions/Workspace'
-            additionalProperties: false
+            $ref: '#/definitions/Workspace'
       responses:
         '200':
           description: Request processed. See response body.
@@ -897,9 +891,10 @@ paths:
     get:
       summary: Returns child nodes of a workspace path
       description: |
-        Workspaces are organized into a hierarchical namespace.  This method returns a
-        JSON array containing every workspace name which is a child of the specified
-        path.
+        Workspaces are organized into a hierarchical namespace. A child
+        workspace having only a 'name' key represents an additional level of
+        hierarchy. A child workspace having a 'name' key and also other keys
+        is a workspace.
 
       operationId: vtrqWorkspaceChildren
       tags:


### PR DESCRIPTION
…re consistent (and accurate).  Clarified a description.

Yefim, perhaps this addresses your concern about what you saw on cnc:6130.