### PR TITLE
vcnc-rest: clone a specific version of swagger-ui, …

### DIFF
--- a/vcnc-rest/static/Makefile.am
+++ b/vcnc-rest/static/Makefile.am
@@ -12,7 +12,7 @@
 all:
 	if [ ! -d $(top_srcdir)/static/swagger-ui ]; then \
 	  (cd $(top_srcdir)/static; \
-	  $(PROG_GIT) clone https://github.com/swagger-api/swagger-ui.git; \
+	  $(PROG_GIT) clone --depth 1 --branch v2.2.10 https://github.com/swagger-api/swagger-ui.git; \
 	  rm -rf swagger-ui/.git) \
 	fi
 


### PR DESCRIPTION
…the last release of swagger-ui 2.x.  3.x breaks the way we are serving it from vcnc-rest.

Some day, we might want to integrate 3.x into vcnc-rest.  Until then, this will keep things working and stable.