### PR TITLE
vcnc-rest: corrected the 'GET workspace children' response …

### DIFF
--- a/vcnc-rest/api/v1api.yaml
+++ b/vcnc-rest/api/v1api.yaml
@@ -1028,7 +1028,7 @@ paths:
               children:
                 type: array
                 items:
-                  $ref: '#/definitions/Workspace'
+                  type: string
         default:
           description: HTTP error
           schema:
@@ -1400,11 +1400,3 @@ definitions:
     items:
       $ref: '#/definitions/WorkspaceEntry'
 
-  Workspace:
-    type: object
-    properties:
-      name:
-        type: string
-        example: my-workspace
-      spec:
-        $ref: '#/definitions/WorkspaceSpec'


### PR DESCRIPTION
…specification.

This addresses issue #16. It wasn't causing problems because it described the _response_ message, which we currently don't validate while vcnc-rest is running.  (Although it would be cool to do so).

Nevertheless, it is important that we fixed the documentation.