### PR TITLE
vcnc-rest: housekeeping and a fixed typo

### DIFF
--- a/vcnc-rest/addon/binding.gyp
+++ b/vcnc-rest/addon/binding.gyp
@@ -53,7 +53,6 @@
 	"/opt/frqu/TOOLROOT/lib64/libcpuid.a",
 	"/opt/frqu/TOOLROOT/lib64/libev.a",
 	"/opt/frqu/TOOLROOT/lib64/libutils.a",
-	"/opt/frqu/TOOLROOT/lib64/liblog4cpp.a",
 	"-ltbbmalloc",
 	"-lboost_thread",
 	"-lboost_system"

--- a/vcnc-rest/addon/src/cnctrq/cnctrqWorkspaceWorker.cc
+++ b/vcnc-rest/addon/src/cnctrq/cnctrqWorkspaceWorker.cc
@@ -163,7 +163,7 @@ namespace cnc {
         {
 //          std::cout << "Workspace children\n";
           string_type arr_ws;
-//          _workspace_list.ExportJson(arr_ws, true);
+          _workspace_list.ExportJson(arr_ws, true);
 //          std::cout << "arr_ws: " << arr_ws << "\n";
           Nan::Set(rtn
                    , Nan::New("ws_children").ToLocalChecked()


### PR DESCRIPTION
Synchronizing with Perforce. This (should) put the remaining Perforce-side changes into master.