### PR TITLE
'nvm link' doesn't work when deployed.

### DIFF
--- a/vcnc-server/Makefile.am
+++ b/vcnc-server/Makefile.am
@@ -30,5 +30,5 @@ clean-local:
 
 install-data-local:
 	find $(top_srcdir) -name '*~' -exec rm '{}' ';'
-	mkdir $(DESTDIR)$(prefix)/share/vcnc
+	mkdir -p $(DESTDIR)$(prefix)/share/vcnc
 	rsync -a $(top_srcdir) $(DESTDIR)$(prefix)/share/vcnc

--- a/vcnc-server/vcnc-core/package.json
+++ b/vcnc-server/vcnc-core/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "preinstall": "npm link ../js-extension",
     "start": "LD_LIBRARY_PATH=/opt/frqu/TOOLROOT/lib64 node ./app.js",
     "gdb": "LD_LIBRARY_PATH=/opt/frqu/TOOLROOT/lib64 gdb --args node ./app.js",
     "lint": "eslint app.js api lib routes",

--- a/vcnc-server/vcnc-rest/app.js
+++ b/vcnc-server/vcnc-rest/app.js
@@ -8,7 +8,7 @@
 // Set the DEBUG environment variable to enable debug output
 // process.env.DEBUG = 'swagger:middleware';
 
-const config = require('vcnc-core/src/lib/configuration');
+const config = require('../vcnc-core/src/lib/configuration');
 //
 //  Express
 const express = require('express');
@@ -18,13 +18,13 @@ const Middleware = require('swagger-express-middleware');
 //
 //  Websockets
 const WebSocket = require('ws');
-const WebSocketHandler = require('vcnc-core/src/lib/websocket');
+const WebSocketHandler = require('../vcnc-core/src/lib/websocket');
 //
 const path = require('path');
 const http = require('http');
 const cors = require('cors');
-const grid = require('vcnc-core/src/lib/grid');
-const rethink = require('vcnc-core/src/lib/rethink');
+const grid = require('../vcnc-core/src/lib/grid');
+const rethink = require('../vcnc-core/src/lib/rethink');
 //
 //  Initialize the C++ extension
 //
@@ -33,7 +33,7 @@ const extensionPath = '../js-extension/build/Release/cnctrq_client';
 const CnctrqClient = require(extensionPath).CnctrqClient;
 const cnctrqClient = new CnctrqClient();
 cnctrqClient.call_me_first(path.join(__dirname, '..'));
-const fulfill202 = require('vcnc-core/src/lib/fulfill202');
+const fulfill202 = require('../vcnc-core/src/lib/fulfill202');
 
 function installStaticContent(app) {
   //

--- a/vcnc-server/vcnc-rest/package.json
+++ b/vcnc-server/vcnc-rest/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "preinstall": "npm link ../vcnc-core; npm link ../js-extension",
     "build": "npm run json-ize; npm run generate",
     "start": "npm run build; LD_LIBRARY_PATH=/opt/frqu/TOOLROOT/lib64 node ./app.js",
     "generate": "generate-md --input doc --output static/doc-html --layout mixu-page",

--- a/vcnc-server/vcnc-rest/src/routes/test.js
+++ b/vcnc-server/vcnc-rest/src/routes/test.js
@@ -8,7 +8,7 @@
  *  @module
  */
 // eslint-disable-next-line import/no-extraneous-dependencies
-const fulfill202 = require('vcnc-core/src/lib/fulfill202.js').fulfill202;
+const fulfill202 = require('../../../vcnc-core/src/lib/fulfill202.js').fulfill202;
 
 function cnctrqClientMoxiate(input, latency, cb) {
   //  Set the timeout emulating the backend latency

--- a/vcnc-server/vcnc-rest/src/routes/v1.js
+++ b/vcnc-server/vcnc-rest/src/routes/v1.js
@@ -9,12 +9,12 @@
  */
 /* eslint-disable import/no-extraneous-dependencies */
 
-const fulfill202 = require('vcnc-core/src/lib/fulfill202.js').fulfill202;
+const fulfill202 = require('../../../vcnc-core/src/lib/fulfill202.js').fulfill202;
 const CnctrqClient = require('../../../js-extension/build/Release/cnctrq_client.node').CnctrqClient;
 
 const cnctrqClient = new CnctrqClient();
-const grid = require('vcnc-core/src/lib/grid.js');
-const config = require('vcnc-core/src/lib/configuration.js');
+const grid = require('../../../vcnc-core/src/lib/grid.js');
+const config = require('../../../vcnc-core/src/lib/configuration.js');
 
 //
 //  Inject latency for testing

--- a/vcnc-server/vcnc-rest/src/routes/v2.js
+++ b/vcnc-server/vcnc-rest/src/routes/v2.js
@@ -9,12 +9,12 @@
  */
 /* eslint-disable import/no-extraneous-dependencies */
 
-const fulfill202 = require('vcnc-core/src/lib/fulfill202.js').fulfill202;
+const fulfill202 = require('../../../vcnc-core/src/lib/fulfill202.js').fulfill202;
 const CnctrqClient = require('../../../js-extension/build/Release/cnctrq_client.node').CnctrqClient;
 
 const cnctrqClient = new CnctrqClient();
-const grid = require('vcnc-core/src/lib/grid.js');
-const config = require('vcnc-core/src/lib/configuration.js');
+const grid = require('../../../vcnc-core/src/lib/grid.js');
+const config = require('../../../vcnc-core/src/lib/configuration.js');
 
 //
 //  Inject latency for testing


### PR DESCRIPTION
'nvm link' works by adding symbolic links inside $NVM_DIR/node_modules and inside the caller's node_modules.  The links use absolute paths that break when deployment copies the packages into different directories.

Instead, require() is given a relative path to the well-known location of the other package.  For example, since vcnc-core and vcnc-rest are siblings, vcnc-rest/app.js uses the path `../vcnc-core/src/lib/configure`

This is pretty ugly, but making it pretty isn't urgent.  I'm leaving it in place for now.  We can revisit it if it becomes a problem in the future.