### PR TITLE
vcnc-server: update the example systemd service file

### DIFF
--- a/vcnc-server/installer/vcnc.service
+++ b/vcnc-server/installer/vcnc.service
@@ -12,9 +12,17 @@
 Description=VelStor vCNC server
 After=vcnc-redis.service
 BindsTo=vcnc-redis.service
+After=vcnc-rethinkdb.service
+BindsTo=vcnc-rethinkdb.service
 
 [Service]
 Type=simple
+#
+#  Two configuration files have fixed locations:
+#    ${DEPLOY_DIR}/share/vcnc/config/vcnc-pepsis.conf
+#    ${DEPLOY_DIR}/share/vcnc/config/vcnc-config.yaml
+#
+#  Use "ExecStartPre cp src dest" to support other configuration file locations.
 ExecStart=/opt/velstor-vcnc/bin/vcnc
 Restart=always
 StandardOutput=syslog+console
@@ -23,7 +31,7 @@ SyslogIdentifier=velstor-vcnc
 User=root
 Group=root
 Environment=NODE_ENV=production
-Environment=VELSTOR_VCNC_PORT=5500
+Environment=VELSTOR_VCNC_PORT=6130
 
 [Install]
 WantedBy=remote-fs.target


### PR DESCRIPTION
The example vcnc.server file was out of date. This is a minor thing: the file isn't used by Dave or the Kennel. 

Just for good form, I added the dependency on rethinkdb, an explanation of the rather non-standard way two configuration files work, and updated the default port to our current recommendation.