### PR TITLE
mock-sampler: generates reasonable-looking mock dashboard data 

### DIFF
--- a/vcnc-server/config/vcnc-config.yaml
+++ b/vcnc-server/config/vcnc-config.yaml
@@ -32,6 +32,17 @@ fulfill202:
   #  response is issued.
   response: 1
 
+mockSampler:
+  #
+  #  The maximum number of samples stored.
+  maxEntries: 100
+  #
+  #  The RethinkDB table where the real-time dashboard data is stored.
+  table: mockSampler
+  #
+  #  The period (1/rate) of the data in ms
+  period: 10000
+
 peercache:
   #
   #  The /vtrq/... endpoints specify the vTRQ ID as part of the request.

--- a/vcnc-server/vcnc-core/src/lib/mockDashboardData.js
+++ b/vcnc-server/vcnc-core/src/lib/mockDashboardData.js
@@ -1,3 +1,88 @@
-/**
- * Created by nick on 4/11/17.
- */
+/*  eslint-disable no-restricted-properties */
+
+//  Gaussian random number generation taken from
+//
+//  http://stackoverflow.com/a/22080644 and http://jsfiddle.net/Xotic750/3rfT6/
+//
+const crypto = require('crypto');
+
+const boxMullerRandom = (() => {
+  let phase = 0;
+  let RAND_MAX;
+  let array;
+  let random;
+  let x1;
+  let x2;
+  let w;
+  let z;
+
+  if (crypto && typeof crypto.getRandomValues === 'function') {
+    RAND_MAX = Math.pow(2, 32) - 1;
+    array = new Uint32Array(1);
+    random = (() => {
+      crypto.getRandomValues(array);
+
+      return array[0] / RAND_MAX;
+    });
+  } else {
+    random = Math.random;
+  }
+
+  return () => {
+    if (!phase) {
+      do {
+        x1 = (2.0 * random()) - 1.0;
+        x2 = (2.0 * random()) - 1.0;
+        w = (x1 * x1) + (x2 * x2);
+      } while (w >= 1.0);
+
+      w = Math.sqrt((-2.0 * Math.log(w)) / w);
+      z = x1 * w;
+    } else {
+      z = x2 * w;
+    }
+
+    phase = !phase;
+
+    return z;
+  };
+})();
+
+//
+//  Calls function 'f' as many times as necessary to return a value on the
+//  interval [min, max]
+//
+function within(min, max, f) {
+  let rtn = f();
+  while (rtn < min || rtn > max) { rtn = f(); }
+  return rtn;
+}
+
+//
+//  Returns a function that, when called, returns the next value of a
+//  Gaussian random walk.
+//
+function trend(min, max, initial = 0, scale = 1) {
+  let value = initial;
+  return () => {
+    value = within(min, max, () => value + (scale * boxMullerRandom()));
+    return value;
+  };
+}
+
+//
+//  Returns a function that, when called, returns a mock dashboard data object
+//  for a time point.
+//
+function mockDashboardData() {
+  const fVtrq = trend(0, 80, 70, 2);
+  const fVpm = trend(10, 70, 50, 2);
+  const fStorageEfficiency = trend(-1, 10, 1, 0.5);
+  return () => ({
+    storageEfficiency: fStorageEfficiency(),
+    rVtrq: fVtrq(),
+    rVpm: fVpm(),
+  });
+}
+
+module.exports = mockDashboardData();

--- a/vcnc-server/vcnc-core/src/lib/mockSampler.js
+++ b/vcnc-server/vcnc-core/src/lib/mockSampler.js
@@ -1,0 +1,65 @@
+/*
+ *    Copyright (C) 2017    IC Manage Inc.
+ *
+ *    See the file 'COPYING' for license information.
+ */
+const config = require('./configuration.js');
+const r = require('rethinkdb');
+const mockDashBoardData = require('./mockDashboardData');
+
+let cnxtn = null;
+const { table, maxEntries } = config.mockSampler;
+
+/**
+ *  Initializes the mockSampler module, creating a connection object
+ *  and creating the table if necessary.
+ *
+ *  @return {promise} A promise fulfilled when the connection is ready.
+ */
+function init() {
+  return r.connect(config.rethinkdb.connection)
+  .then((conn) => {
+    cnxtn = conn;  // save the connection for later reuse
+  })
+  .then(() =>
+    //  Look for the table in the database
+    r.tableList().filter(v => v.eq(table)).run(cnxtn)
+  )
+  .then((lst) => {
+    // Create the table if necessary.
+    if (lst.length === 0) {
+      return r.tableCreate(table).run(cnxtn);
+    }
+    return Promise.resolve();
+  });
+}
+
+function push(entry) {
+  return r.table(table).insert(
+    Object.assign({}, entry, { timestamp: r.now() })
+  ).run(cnxtn)
+  .then(() => r.table(table).count().run(cnxtn))
+  .then((size) => {
+    //
+    //  Reduce the size of the table when it grows to twice its desired size.
+    //  This is pretty silly.  We won't actually do this.  Instead,
+    //  we'll have a table that acts like a ring buffer. Or something else.
+    if (size > maxEntries * 2) {
+      return r.table(table)
+      .orderBy(r.asc('timestamp'))
+      .limit(maxEntries)
+      .delete({ durability: 'soft' })
+      .run(cnxtn);
+    }
+    return Promise.resolve();
+  });
+}
+
+function run(period) {
+  return () => setInterval(() => push(mockDashBoardData()), period);
+}
+
+module.exports = {
+  init,
+  run,
+};

--- a/vcnc-server/vcnc-sampler/app-mock.js
+++ b/vcnc-server/vcnc-sampler/app-mock.js
@@ -1,0 +1,29 @@
+/*
+ *    Copyright (C) 2015-2016    IC Manage Inc.
+ *
+ *    See the file 'COPYING' for license information.
+ */
+/* eslint-disable import/no-extraneous-dependencies */
+//
+//  Use the vcnc-server common configuration
+const config = require('../vcnc-core/src/lib/configuration');
+//
+//  Use the vcnc-server common rethink-db handling
+const rethink = require('../vcnc-core/src/lib/rethink');
+//
+//  The mock sampler code lives in the core. It could also live locally in
+//  ./src/lib/mockSampler.
+//  const mockSampler = require('./src/lib/mockSampler');
+const mockSampler = require('../vcnc-core/src/lib/mockSampler');
+//
+//  Initialize the modules
+rethink.init()
+.then(() => mockSampler.init(config.mockSampler.table))
+.catch((err) => {
+  console.log(err); // eslint-disable-line
+  console.log('Exiting...'); // eslint-disable-line
+  process.exit(1);
+});
+//
+//  Start the mock process. Stopped by external SIGTERM
+mockSampler.run(config.mockSampler.period)();


### PR DESCRIPTION
... and pushes it into RethinkDB

Serves as an example for:

- Using the common configuration mechanism
- Initializing RethinkDB (using the shared RethinkDB code)
- Initializing a module that manages a table in RethinkDB
- Referring to modules that live in a different node.js program
- Preferred code structure (all j/s code other than app.js under the /src/ directory)

Please focus your initial efforts on pulling data out of the vda and processing it.  I'm still playing around with the RethinkDB schema.  If you can just write the dashboard object { rVtrq: 15, ... } to console that would be fine to get started.

Lemme know if you have any questions!

Thanks!