### PR TITLE
vcnc web/server: push the mock dashboard data from vcnc-rest to vcnc-…

### DIFF
--- a/vcnc-server/vcnc-core/src/lib/mockDashboardData.js
+++ b/vcnc-server/vcnc-core/src/lib/mockDashboardData.js
@@ -85,4 +85,4 @@ function mockDashboardData() {
   });
 }
 
-module.exports = mockDashboardData();
+module.exports = mockDashboardData;

--- a/vcnc-server/vcnc-core/src/lib/mockSampler.js
+++ b/vcnc-server/vcnc-core/src/lib/mockSampler.js
@@ -5,7 +5,7 @@
  */
 const config = require('./configuration.js');
 const r = require('rethinkdb');
-const mockDashBoardData = require('./mockDashboardData');
+const mockDashBoardData = require('./mockDashboardData')();
 
 let cnxtn = null;
 const { table, maxEntries } = config.mockSampler;

--- a/vcnc-server/vcnc-core/src/lib/websocket.js
+++ b/vcnc-server/vcnc-core/src/lib/websocket.js
@@ -1,11 +1,11 @@
 //
 /* eslint-disable no-console */
 const url = require('url');
+const mockDashboardData = require('./mockDashboardData')();
 
 function makeHandler() {
   let interval = null;
-  let count = 0;
-  return ws => {
+  return (ws) => {
     const location = url.parse(ws.upgradeReq.url, true);
     console.log('INFO-WS: Connected from ', location);
 
@@ -13,8 +13,8 @@ function makeHandler() {
       console.log('INFO-WS: opened');
     });
 
-    ws.on('message', message => {
-      console.log('INFO-ws: received: %s', message)
+    ws.on('message', (message) => {
+      console.log('INFO-ws: received: %s', message);
     });
 
     ws.on('close', () => {
@@ -23,13 +23,8 @@ function makeHandler() {
     });
 
     interval = setInterval(() => {
-      ws.send(JSON.stringify({
-        rVtrq: 50 + count,
-        rVpm: 40 + count,
-        rVp: 30 + 2 * count,
-      }));
-      count += 1;
-    }, 15000);
+      ws.send(JSON.stringify(mockDashboardData()));
+    }, 10000);
   };
 }
 

--- a/vcnc-web/src/containers/ExternalEvents.jsx
+++ b/vcnc-web/src/containers/ExternalEvents.jsx
@@ -1,8 +1,7 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import Websocket from 'react-websocket';
 import * as actions from '../actions/realtimeActions';
-import { trend } from '../lib/sequence';
 
 //
 //  ExternalEvents injects external data (for example data received from a
@@ -13,61 +12,25 @@ import { trend } from '../lib/sequence';
 //
 //  See Dan Abramov's answer: https://github.com/reactjs/redux/issues/916#issuecomment-149190441
 
-function startFrquPushSimulation(dispatch) {
-  const fVtrq = trend(0, 80, 70, 2);
-  const fVpm = trend(10, 70, 50, 2);
-  const fVp = trend(2, 30, 2, 2);
-  const makeData = () => {
-    const rVtrq = fVtrq();
-    const rVpm = fVpm();
-    const rVp = fVp();
-    const sum = rVtrq + rVpm + rVp;
-    return {
-      rVtrq: (rVtrq / sum) * 100,
-      rVpm: (rVpm / sum) * 100,
-      rVp: (rVp / sum) * 100,
-    };
+function ExternalEvents(props) {
+  const handleData = (data) => {
+    const { rVpm, rVtrq, storageEfficiency } = JSON.parse(data);
+    props.dispatch(
+      actions.updateVtrqPerformance({ storageEfficiency }));
+    props.dispatch(actions.updatePeercachePerformance({
+      rVpm,
+      rVtrq,
+      rVp: 13,
+    }));
   };
-  dispatch(actions.updatePeercachePerformance(makeData()));
-  //
-  window.setInterval(() => {
-    dispatch(actions.updatePeercachePerformance(makeData()));
-  },
-  10000,
+
+  return (
+    <Websocket url="ws://localhost:6130/" onMessage={handleData} />
   );
-}
-
-function startVtrqPullSimulation(dispatch) {
-  const fStorageEfficiency = trend(-1, 10, 1, 0.5);
-  window.setInterval(() => {
-    dispatch(actions.updateVtrqPerformance({ storageEfficiency: fStorageEfficiency() }));
-  },
-  15000,
-  );
-}
-
-function handleData(data) {
-  console.log(JSON.parse(data));
-}
-
-
-class ExternalEvents extends Component {
-
-  componentDidMount() {
-    startFrquPushSimulation(this.props.dispatch);
-    startVtrqPullSimulation(this.props.dispatch);
-  }
-
-  render() {
-    return (
-      <Websocket url="ws://localhost:6130/" onMessage={handleData} />
-    );
-  }
 }
 
 ExternalEvents.propTypes = {
   dispatch: PropTypes.func.isRequired,
 };
-
 
 export default connect()(ExternalEvents);


### PR DESCRIPTION
…web over a websocket

We can now stream (fake) dashboard data from vcnc-rest to the web console. It's also all the (fake) data we need to develop the widgets Shiv wants for DAC.

Ultimately (but before DAC) we will have to move the websocket server off of vcnc-rest, but it's not clear right now where it's going to move to.