### PR TITLE
vcnc-web: fix deprecated PropTypes package, as advised by React 15.5.…

### DIFF
--- a/vcnc-web/package.json
+++ b/vcnc-web/package.json
@@ -36,6 +36,7 @@
     "chart.js": "2.5.0",
     "material-ui": "0.17.0",
     "object-assign": "4.1.0",
+    "prop-types": "15.5.8",
     "react": "^15.4.1",
     "react-chartjs-2": "2.0.5",
     "react-dom": "^15.4.1",

--- a/vcnc-web/src/components/AppFrame.jsx
+++ b/vcnc-web/src/components/AppFrame.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-nested-ternary */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import spacing from 'material-ui/styles/spacing';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';

--- a/vcnc-web/src/components/AppNavDrawer.jsx
+++ b/vcnc-web/src/components/AppNavDrawer.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Drawer from 'material-ui/Drawer';
 import Divider from 'material-ui/Divider';
 import Subheader from 'material-ui/Subheader';

--- a/vcnc-web/src/components/FilesPageLayout.jsx
+++ b/vcnc-web/src/components/FilesPageLayout.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import PageBar from './PageBar';
 
 const FilesPageLayout = props => (

--- a/vcnc-web/src/components/FrquCacheDoughnut.jsx
+++ b/vcnc-web/src/components/FrquCacheDoughnut.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Doughnut } from 'react-chartjs-2';
 import muiThemeable from 'material-ui/styles/muiThemeable';
 

--- a/vcnc-web/src/components/FrquCacheTrend.jsx
+++ b/vcnc-web/src/components/FrquCacheTrend.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Line } from 'react-chartjs-2';
 
 function sliceAndFill(arr, size, fill = null) {

--- a/vcnc-web/src/components/HomePageLayout.jsx
+++ b/vcnc-web/src/components/HomePageLayout.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import PageBar from './PageBar';
 import Dashboard from './Dashboard';
 

--- a/vcnc-web/src/components/MountsPageLayout.jsx
+++ b/vcnc-web/src/components/MountsPageLayout.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import PageBar from './PageBar';
 
 const MountsPageLayout = props => (

--- a/vcnc-web/src/components/PageBar.jsx
+++ b/vcnc-web/src/components/PageBar.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import AppBar from 'material-ui/AppBar';
 import muiThemeable from 'material-ui/styles/muiThemeable';
 

--- a/vcnc-web/src/components/VtrqSetter.jsx
+++ b/vcnc-web/src/components/VtrqSetter.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import DropDownMenu from 'material-ui/DropDownMenu';
 import MenuItem from 'material-ui/MenuItem';
 

--- a/vcnc-web/src/components/WidgetFrame.jsx
+++ b/vcnc-web/src/components/WidgetFrame.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Card, CardHeader } from 'material-ui';
 import muiThemeable from 'material-ui/styles/muiThemeable';
 

--- a/vcnc-web/src/components/WorkspacesPageLayout.jsx
+++ b/vcnc-web/src/components/WorkspacesPageLayout.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import PageBar from './PageBar';
 
 const WorkspacesPageLayout = props => {

--- a/vcnc-web/src/containers/App.jsx
+++ b/vcnc-web/src/containers/App.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as actions from '../actions/appActions';

--- a/vcnc-web/src/containers/CurrentVtrqSetter.jsx
+++ b/vcnc-web/src/containers/CurrentVtrqSetter.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as actions from '../actions/settingsActions';

--- a/vcnc-web/src/containers/ExternalEvents.jsx
+++ b/vcnc-web/src/containers/ExternalEvents.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Websocket from 'react-websocket';
 import * as actions from '../actions/realtimeActions';

--- a/vcnc-web/src/containers/FilesPage.jsx
+++ b/vcnc-web/src/containers/FilesPage.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as appActions from '../actions/appActions';

--- a/vcnc-web/src/containers/FrquCacheDoughnutWidget.jsx
+++ b/vcnc-web/src/containers/FrquCacheDoughnutWidget.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import FrquCacheDoughnut from '../components/FrquCacheDoughnut';
 

--- a/vcnc-web/src/containers/FrquCacheTrendWidget.jsx
+++ b/vcnc-web/src/containers/FrquCacheTrendWidget.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import muiThemeable from 'material-ui/styles/muiThemeable';

--- a/vcnc-web/src/containers/HomePage.jsx
+++ b/vcnc-web/src/containers/HomePage.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as appActions from '../actions/appActions';

--- a/vcnc-web/src/containers/MountsPage.jsx
+++ b/vcnc-web/src/containers/MountsPage.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as appActions from '../actions/appActions';

--- a/vcnc-web/src/containers/StorageEfficiencyNumberWidget.jsx
+++ b/vcnc-web/src/containers/StorageEfficiencyNumberWidget.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 const StorageEfficiencyNumberWidget = props => (

--- a/vcnc-web/src/containers/WorkspacesPage.jsx
+++ b/vcnc-web/src/containers/WorkspacesPage.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as appActions from '../actions/appActions';


### PR DESCRIPTION
… Ironically, Facebook's own fbjs package hasn't done this yet, so the warning doesn't go away

Facebook has decided to break out PropTypes from package React. The rationale is described [here](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html).

With this changeset, our codebase should be ready for React 16.x