### PR TITLE
Mock data via rethinkdb

### DIFF
--- a/vcnc-server/vcnc-core/src/lib/mockSampler.js
+++ b/vcnc-server/vcnc-core/src/lib/mockSampler.js
@@ -30,7 +30,9 @@ function init() {
   .then((lst) => {
     // Create the table if necessary.
     if (lst.length === 0) {
-      return r.tableCreate(table).indexCreate('timestamp').run(cnxtn);
+      // return r.tableCreate(table).indexCreate('timestamp').run(cnxtn);
+      return r.tableCreate(table).run(cnxtn)
+        .then(() => r.table(table).indexCreate('timestamp').run(cnxtn));
     }
     return Promise.resolve();
   });

--- a/vcnc-server/vcnc-core/src/lib/mockSampler.js
+++ b/vcnc-server/vcnc-core/src/lib/mockSampler.js
@@ -58,6 +58,14 @@ function trim() {
   .delete({ durability: 'soft' }).run(cnxtn);
 }
 
+function getTable() {
+  return r.table(table);
+}
+
+function getConnection() {
+  return cnxtn;
+}
+
 /**
  * Runs the mock data simulation.
  *
@@ -69,6 +77,8 @@ function run() {
 }
 
 module.exports = {
+  getConnection,
+  getTable,
   init,
   run,
 };

--- a/vcnc-server/vcnc-core/src/lib/websocket.js
+++ b/vcnc-server/vcnc-core/src/lib/websocket.js
@@ -1,9 +1,12 @@
 //
 /* eslint-disable no-console */
+const config = require('./configuration.js');
 const url = require('url');
 const mockDashboardData = require('./mockDashboardData')();
 const mockSampler = require('./mockSampler');
 const r = require('rethinkdb');
+
+let connection = null;
 
 function makeMockHandler() {
   let interval = null;
@@ -30,10 +33,47 @@ function makeMockHandler() {
   };
 }
 
+function init() {
+  return r.connect(config.rethinkdb.connection)
+  .then((conn) => {
+    connection = conn;
+  });
+}
+
 function makeMockRethinkHandler() {
+  let changeCursor = null;
   return (ws) => {
     const location = url.parse(ws.upgradeReq.url, true);
     console.log('INFO-WS: Connected from ', location);
+    //
+    //  Start things off by blasting the 100 most recent timepoints.
+    //
+    mockSampler.getTable()
+    .orderBy({ index: r.desc('timestamp') })
+    .limit(100)
+    .orderBy('timestamp')
+    .run(connection)
+    .then((cursor) => {
+      cursor.each((err, entry) => {
+        const { rVpm, rVtrq, storageEfficiency } = entry;
+        ws.send(JSON.stringify({ rVpm, rVtrq, storageEfficiency }));
+      });
+    });
+    //
+    //  Subscribe to changes in the RethinkDB dashboard table.
+    //
+    mockSampler.getTable()
+    .changes()
+    .run(connection, (err, cursor) => {
+      changeCursor = cursor;
+      cursor.each((error, change) => {
+        if (change !== undefined && change.new_val) {
+          const { rVpm, rVtrq, storageEfficiency } = change.new_val;
+          ws.send(JSON.stringify({ rVpm, rVtrq, storageEfficiency }));
+        }
+      });
+    })
+    .catch(() => console.log('caught cursor error'));
 
     ws.on('open', () => {
       console.log('INFO-WS: opened');
@@ -45,28 +85,13 @@ function makeMockRethinkHandler() {
 
     ws.on('close', () => {
       console.log('INFO-ws: disconnected');
-      // clearInterval(interval);
-    });
-    //
-    //  Subscribe to changes in the RethinkDB dashboard table.
-    //
-    mockSampler.getTable()
-    // .orderBy({ index: r.desc('timepoint') })
-    // .limit(10)
-    .changes()
-    .run(mockSampler.getConnection(), (err, cursor) => {
-      // cursor.each((e, y) => console.log(y));
-      cursor.each((error, change) => {
-        if (change.new_val) {
-          const { rVpm, rVtrq, storageEfficiency } = change.new_val;
-          ws.send(JSON.stringify({ rVpm, rVtrq, storageEfficiency }));
-        }
-      });
+      changeCursor.close();
     });
   };
 }
 
 module.exports = {
+  init,
   makeMockRethinkHandler,
   makeMockHandler,
   makeHandler: makeMockRethinkHandler,

--- a/vcnc-server/vcnc-core/src/lib/websocket.js
+++ b/vcnc-server/vcnc-core/src/lib/websocket.js
@@ -2,8 +2,10 @@
 /* eslint-disable no-console */
 const url = require('url');
 const mockDashboardData = require('./mockDashboardData')();
+const mockSampler = require('./mockSampler');
+const r = require('rethinkdb');
 
-function makeHandler() {
+function makeMockHandler() {
   let interval = null;
   return (ws) => {
     const location = url.parse(ws.upgradeReq.url, true);
@@ -28,6 +30,44 @@ function makeHandler() {
   };
 }
 
+function makeMockRethinkHandler() {
+  return (ws) => {
+    const location = url.parse(ws.upgradeReq.url, true);
+    console.log('INFO-WS: Connected from ', location);
+
+    ws.on('open', () => {
+      console.log('INFO-WS: opened');
+    });
+
+    ws.on('message', (message) => {
+      console.log('INFO-ws: received: %s', message);
+    });
+
+    ws.on('close', () => {
+      console.log('INFO-ws: disconnected');
+      // clearInterval(interval);
+    });
+    //
+    //  Subscribe to changes in the RethinkDB dashboard table.
+    //
+    mockSampler.getTable()
+    // .orderBy({ index: r.desc('timepoint') })
+    // .limit(10)
+    .changes()
+    .run(mockSampler.getConnection(), (err, cursor) => {
+      // cursor.each((e, y) => console.log(y));
+      cursor.each((error, change) => {
+        if (change.new_val) {
+          const { rVpm, rVtrq, storageEfficiency } = change.new_val;
+          ws.send(JSON.stringify({ rVpm, rVtrq, storageEfficiency }));
+        }
+      });
+    });
+  };
+}
+
 module.exports = {
-  makeHandler,
+  makeMockRethinkHandler,
+  makeMockHandler,
+  makeHandler: makeMockRethinkHandler,
 };

--- a/vcnc-server/vcnc-rest/app.js
+++ b/vcnc-server/vcnc-rest/app.js
@@ -20,6 +20,7 @@ const Middleware = require('swagger-express-middleware');
 const WebSocket = require('ws');
 const WebSocketHandler = require('../vcnc-core/src/lib/websocket');
 const mockSampler = require('../vcnc-core/src/lib/mockSampler');
+const websocket = require('../vcnc-core/src/lib/websocket');
 //
 const path = require('path');
 const http = require('http');
@@ -286,6 +287,7 @@ module.exports = (() => {
   rethink.init()
   .then(() => grid.init())
   .then(() => mockSampler.init())
+  .then(() => websocket.init())
   .then(() => configureSwaggerMiddleware(app, 'src/api/v1api.json'))
   .then(() => configureSwaggerMiddleware(app, 'src/api/v2api.json'))
   .then(() => {

--- a/vcnc-server/vcnc-rest/app.js
+++ b/vcnc-server/vcnc-rest/app.js
@@ -19,6 +19,7 @@ const Middleware = require('swagger-express-middleware');
 //  Websockets
 const WebSocket = require('ws');
 const WebSocketHandler = require('../vcnc-core/src/lib/websocket');
+const mockSampler = require('../vcnc-core/src/lib/mockSampler');
 //
 const path = require('path');
 const http = require('http');
@@ -284,6 +285,7 @@ module.exports = (() => {
   installStaticContent(app);
   rethink.init()
   .then(() => grid.init())
+  .then(() => mockSampler.init())
   .then(() => configureSwaggerMiddleware(app, 'src/api/v1api.json'))
   .then(() => configureSwaggerMiddleware(app, 'src/api/v2api.json'))
   .then(() => {

--- a/vcnc-server/vcnc-sampler/app-mock.js
+++ b/vcnc-server/vcnc-sampler/app-mock.js
@@ -26,4 +26,4 @@ rethink.init()
 });
 //
 //  Start the mock process. Stopped by external SIGTERM
-mockSampler.run(config.mockSampler.period)();
+mockSampler.run(config.mockSampler.period);


### PR DESCRIPTION
This changeset:

1. More efficiently manages insertion of realtime data into RethinkDB (app-mock.js)
2. In vcnc-rest, it subscribes to changes and pushes them to the web console as they occur.

This proves that, if vcnc-sampler puts the real time data into RethinkDB, the data will make it all the way to the web browser and be displayed correctly.