### PR TITLE
Grid get fix

### DIFF
--- a/vcnc-server/vcnc-rest/src/routes/v1.js
+++ b/vcnc-server/vcnc-rest/src/routes/v1.js
@@ -44,14 +44,13 @@ function convertMapVtrqID(maps) {
 //
 // Convert v2-format of workspace to v1 format for back compatibility
 //
-function workspace(jstr) {
+function v2WorkspaceAsV1(jstr) {
   const jsonWs = JSON.parse(jstr.ws);
   const local = jsonWs.writeback === 'never';
-  return {
-    spec:
-      convertMapVtrqID(jsonWs.maps)
-      .map(e => Object.assign({}, e, { local })),
-  };
+  return (
+    convertMapVtrqID(jsonWs.maps)
+    .map(e => Object.assign({}, e, { local }))
+  );
 }
 
 //
@@ -176,7 +175,10 @@ module.exports = (app) => {
               if (result.http_status === 200) {
                 grid.createJob(
                   req.pathParams.job_id,
-                  { workspace_name: req.body.workspace_name, workspace_spec: workspace(result) })
+                  {
+                    workspace_name: req.body.workspace_name,
+                    workspace_spec: v2WorkspaceAsV1(result),
+                  })
                 .then(() => {
                   cb(adapter({
                     http_status: 200,
@@ -607,7 +609,7 @@ module.exports = (app) => {
               //  this level manipulates objects.
               //
               if (result.http_status === 200) {
-                cb(adapter(result, workspace(result)));
+                cb(adapter(result, { spec: v2WorkspaceAsV1(result) }));
               } else {
                 cb(adapter(result));
               }

--- a/vcnc-server/vcnc-rest/src/routes/v1.js
+++ b/vcnc-server/vcnc-rest/src/routes/v1.js
@@ -38,11 +38,17 @@ function convertVtrqID(map) {
 }
 
 function convertMapVtrqID(maps) {
+  if (!Array.isArray(maps)) {
+    return [];
+  }
   return maps.map(e => convertVtrqID(e));
 }
 
 //
-// Convert v2-format of workspace to v1 format for back compatibility
+//  Convert v2-format of workspace to v1 format for back compatibility
+//
+//  This function receives PIDL JSON format (integers are strings and empty
+//  arrays may be empty strings).
 //
 function v2WorkspaceAsV1(jstr) {
   const jsonWs = JSON.parse(jstr.ws);
@@ -55,6 +61,9 @@ function v2WorkspaceAsV1(jstr) {
 
 //
 // Extract workspace children names from  v2-format for back compatibility
+//
+//  This function receives PIDL JSON format (integers are strings and empty
+//  arrays may be empty strings).
 //
 function workspaceChildren(jsonIn) {
   const children = jsonIn.ws_children;


### PR DESCRIPTION
A 'v1' workspace specification is an array.  The v2-to-v1 converter was turning it into an object with a key "spec" and array value.

The confusion comes from the workspace "get" endpoint.  The response body is an object containing a kcy "spec" whose value is a workspace specification (that is, an array).

The fix is to make it clear that the 'workspace' function (renamed to v1WorkspaceAsV2) converts workspaces (type arrary) and then create extra 'spec' level in the workspace::get code.

With this change, the Python code works without modification.
