### PR TITLE
vcnc: restore earlier behavior - all responses have a 'message' key, …

### DIFF
--- a/vcnc-server/vcnc-rest/src/routes/v1.js
+++ b/vcnc-server/vcnc-rest/src/routes/v1.js
@@ -107,12 +107,9 @@ function adapter(fromRpc, onSuccess, onFailure) {
     body: {},
   };
   rtn.body.error_sym = fromRpc.error_sym;
+  rtn.body.message = fromRpc.error_description_brief;
   //
   const successful = (200 <= status && status < 300); // eslint-disable-line yoda
-  if (successful === false) {
-    rtn.body.message = fromRpc.error_description_brief;
-  }
-
   const moreProperties = successful ? onSuccess : onFailure;
   Object.assign(rtn.body, moreProperties);
   return rtn;


### PR DESCRIPTION
…not just the unsuccessful ones

A lot of people depend on the exact form of the HTTP responses... and behavior in general.

Please file a bug report if you come across something in the code that looks wrong.