### PR TITLE
vcnc-server: delete IDE-related files.  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,3 @@
-# Ignore all
-*
-
-# Unignore all with extensions
-!*.*
-
-# Unignore all dirs
-!*/
-
 # Perforce as used at IC Manage
 .icmconfig
 
@@ -15,8 +6,13 @@ build/
 Build/
 _build/
 
-# Webstorm 
+# IDEs
+# .. Webstorm
 .idea/
+# .. Visual Studio Code
+.vscode/
+# .. Eclipse
+.settings/
 
 # Python
 __pycache__/
@@ -55,7 +51,6 @@ autoscan-*.log
 config.h.in
 configure
 configure.scan
-depcomp
 stamp-h1
 *.in
 

--- a/.settings/.jsdtscope
+++ b/.settings/.jsdtscope
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<classpath>
-	<classpathentry kind="src" path=""/>
-	<classpathentry kind="con" path="org.eclipse.wst.jsdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="output" path=""/>
-</classpath>

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "restructuredtext.confPath" : "documentation/conf.py",
-    "restructuredtext.builtDocumentationPath" : "documentation/_build/html",
-    "restructuredtext.updateOnTextChanged" : "true"
-}
-

--- a/vcnc-server/m4/ChangeLog
+++ b/vcnc-server/m4/ChangeLog
@@ -1,0 +1,32 @@
+2011-01-14  gettextize  <bug-gnu-gettext@gnu.org>
+
+	* codeset.m4: New file, from gettext-0.14.1.
+	* gettext.m4: New file, from gettext-0.14.1.
+	* glibc21.m4: New file, from gettext-0.14.1.
+	* iconv.m4: New file, from gettext-0.14.1.
+	* intdiv0.m4: New file, from gettext-0.14.1.
+	* intmax.m4: New file, from gettext-0.14.1.
+	* inttypes.m4: New file, from gettext-0.14.1.
+	* inttypes_h.m4: New file, from gettext-0.14.1.
+	* inttypes-pri.m4: New file, from gettext-0.14.1.
+	* isc-posix.m4: New file, from gettext-0.14.1.
+	* lcmessage.m4: New file, from gettext-0.14.1.
+	* lib-ld.m4: New file, from gettext-0.14.1.
+	* lib-link.m4: New file, from gettext-0.14.1.
+	* lib-prefix.m4: New file, from gettext-0.14.1.
+	* longdouble.m4: New file, from gettext-0.14.1.
+	* longlong.m4: New file, from gettext-0.14.1.
+	* nls.m4: New file, from gettext-0.14.1.
+	* po.m4: New file, from gettext-0.14.1.
+	* printf-posix.m4: New file, from gettext-0.14.1.
+	* progtest.m4: New file, from gettext-0.14.1.
+	* signed.m4: New file, from gettext-0.14.1.
+	* size_max.m4: New file, from gettext-0.14.1.
+	* stdint_h.m4: New file, from gettext-0.14.1.
+	* uintmax_t.m4: New file, from gettext-0.14.1.
+	* ulonglong.m4: New file, from gettext-0.14.1.
+	* wchar_t.m4: New file, from gettext-0.14.1.
+	* wint_t.m4: New file, from gettext-0.14.1.
+	* xsize.m4: New file, from gettext-0.14.1.
+	* Makefile.am: New file.
+


### PR DESCRIPTION
Our policy is now to store no IDE configuration or metadata.  After a trial period of controlling IDE files, we found that it created more problems than it solved.

Also, got rid of the 'ignore all and then whitelist' trickery in .gitignore.  There are a lot of tools that don't understand it, and there weren't that many extension-less files left to ignore, anyway.