### PR TITLE
vcnc-web: optional REST host:port from URL

### DIFF
--- a/vcnc-web/src/lib/restHost.js
+++ b/vcnc-web/src/lib/restHost.js
@@ -5,9 +5,25 @@
  */
 
 function restHost() {
+  //
+  //  Give the URL priority
+  //
+  const params = new URLSearchParams(window.location.search.substring(1));
+  const rest = params.get('rest');
+  if (rest) {
+    return rest;
+  }
+  //
+  //  Otherwise, if the URL is the Slingshot BrowserSync default, use the
+  //  pre-configured product default. This is where a developer's
+  //  vcnc-rest would be listening.
+  //
   if (window.location.host === 'localhost:3000') {
     return 'localhost:6130';
   }
+  //
+  //  Otherwise, use the offset convention programmed into vcnc-rest.
+  //
   const port = parseInt(window.location.port, 10) + 10;
   return `${window.location.hostname}:${port}`;
 }

--- a/vcnc-web/src/lib/restHost.js
+++ b/vcnc-web/src/lib/restHost.js
@@ -7,11 +7,12 @@
 function restHost() {
   //
   //  Give the URL priority
+  //  ... the substring(1) idiom drops the initial '?' See
+  //      https://stackoverflow.com/a/14395123/7702839
   //
   const params = new URLSearchParams(window.location.search.substring(1));
-  const rest = params.get('rest');
-  if (rest) {
-    return rest;
+  if (params.has('rest')) {
+    return params.get('rest');
   }
   //
   //  Otherwise, if the URL is the Slingshot BrowserSync default, use the


### PR DESCRIPTION
Typically, one *really* wants the admin console to connect to the REST host it was launched from.  This assures the two are compatible.

However, during development, it might be useful to connect a vcnc-web console that's under development with an existing vcnc/vtrq/vcnc/grid deployment. That's where this comes in.