### PR TITLE
Doughnut chart should turn grey, not disappear

### DIFF
--- a/vcnc-web/src/constants/muiTheme.js
+++ b/vcnc-web/src/constants/muiTheme.js
@@ -45,6 +45,7 @@ const { primary1Color, textColor } = materialUi.palette;
 
 export const vcnc = {
   palette: {
+    emptyDoughnutColor: grey400,
     storageEfficiencyColor: grey800,
     sumExtentsColor: red500,
     sumStSizeColor: blue500,

--- a/vcnc-web/src/containers/VtrqVpmReadDoughnut.jsx
+++ b/vcnc-web/src/containers/VtrqVpmReadDoughnut.jsx
@@ -4,11 +4,25 @@ import { connect } from 'react-redux';
 import muiThemeable from 'material-ui/styles/muiThemeable';
 import DoughnutWidget from '../components/widgets/DoughnutWidget';
 
+const readRatesAreZero = data => {
+  return data.reduce((accumulator, item) => accumulator + item, 0 ) === 0;
+};
+
 const VtrqVpmDoughnut = (props) => {
-  const { vtrqColor, vpmColor } = props.muiTheme.palette;
-  const backgroundColor = [vtrqColor, vpmColor];
+  //
+  //  When all the values to a Doughnut are zero, jsChart doesn't display
+  //  anything at all.  We prefer to display a grey doughnut (grey to
+  //  indicate that it is "grey-ed out").  Since the values are equally
+  //  zero, we make the areas equal size.
+
+  const { emptyDoughnutColor, vpmColor, vtrqColor } = props.muiTheme.palette;
+  const doughnutIsEmpty = readRatesAreZero(props.data.datasets[0].data)
+  const backgroundColor =
+    doughnutIsEmpty
+      ? [emptyDoughnutColor, emptyDoughnutColor]
+      : [vtrqColor, vpmColor];
   const datasets = [{ data: props.data.datasets[0].data, backgroundColor }];
-  const data = { ...props.data, datasets };
+  const data = { ...props.data, datasets: doughnutIsEmpty ? [{ data: [1, 1] }] : datasets };
 
   return (
     <DoughnutWidget data={data} title={props.title} />


### PR DESCRIPTION
In the chartJS Doughnut widget, if all the display values are zero, chartJS displays nothing (blank space).

This change detects the "all zeros" case and instead displays an equally divided grey torus (doughnut).