### PR TITLE
vcncsampler: provide an environment variable for the vtrq polling per…

### DIFF
--- a/vcnc-server/config/vcnc-config.yaml
+++ b/vcnc-server/config/vcnc-config.yaml
@@ -13,10 +13,12 @@ server:
   interface: all
   #
   #  The period (1/rate) at which to poll the vtrq for storage statistics, in ms.
+  #  This value may be overridden by the VELSTOR_VCNC_VTRQ_POLL_PERIOD_SEC
+  #  environment variable.
   #
-  #  A rate of a few seconds is intendend for customer demo, not production.
+  #  A rate of a few seconds is intended for customer demo, not production.
   #
-  vtrqPollPeriod: 5000
+  vtrqPollPeriod: 20000
 
 fulfill202:
   #
@@ -66,12 +68,12 @@ vcncSampler:
   #  The period extension in ms to prevent data loss
   latency: 500
   #
-  #  hostname
-  hostname: cnc
+  #  The IP address (or hostname) on which to listen for vda posts.
+  #  0.0.0.0 listens on all interfaces.
+  hostname: 0.0.0.0
   #
-  #  port 
+  #  The port at which to listen for vda posts.
   port: 6159 
-
 
 peercache:
   #
@@ -107,7 +109,7 @@ redis:
     #  An alternative way to isolate vcnc instances is by specifying a database
     #  number.  Valid values are between 0 and 15, inclusive.  Default is 0
     db: 0
-    #
+
 rethinkdb:
   #
   #  Connection information for the RethinkDB client.  See
@@ -116,17 +118,26 @@ rethinkdb:
   #  The RethinkDB server itself is configured separately.  The two configurations
   #  must match where they intersect.
   connection:
+    #
     # The host to connect to.
+    # May be overridden by VELSTOR_VCNC_RETHINKDB_HOST
     host: localhost
+    #
     # The port to connect on.
     port: 28015
+    #
     # The default database
+    # May be overridden by VELSTOR_VCNC_RETHINKDB_DB
     db: vcnc_rest
+    #
     # The user account to connect as
     user: admin
+    #
     # The password for the user account to connect as
     password: ''
+    #
     # Timeout period in seconds for the connection to be opened.
+    #
     timeout: 20
     # A hash of options to support SSL connections.
 
@@ -142,6 +153,7 @@ test:
 web:
   #
   #  If true, statically serve the web-based admin console
+  #  May be overridden by VELSTOR_VCNC_WEB_ENABLE
   enabled: true
   #
   #  Serve the console at this offset from server.port

--- a/vcnc-server/vcnc-core/src/lib/configuration.js
+++ b/vcnc-server/vcnc-core/src/lib/configuration.js
@@ -38,6 +38,12 @@ if (conf.fulfill202.baseUrl === undefined) {
   const port = conf.server.port;
   conf.fulfill202.baseUrl = `http://${os.hostname()}:${port}`;
 }
+//
+//  Get the vtrq storage efficiency polling period
+//
+if ('VELSTOR_VCNC_VTRQ_POLL_PERIOD_SEC' in process.env) {
+  conf.vcncSampler.vtrqPollPeriod = parseInt(process.env.VELSTOR_VCNC_VTRQ_POLL_PERIOD_SEC) * 1000
+}
 // console.log('resolved configuration: ', conf);
 
 module.exports = conf;


### PR DESCRIPTION
…iod. Change the default vcncSampler.hostname to 0.0.0.0

This is to fulfull [Wrike <R9026>(https://www.wrike.com/open.htm?id=157602927) which asks for non-config-file ways (preferably command line options) to adjust the vtrq polling period and the vcncSampler.hostname.

We avoid having to alter vcncSampler.hostname by setting its default value to 0.0.0.0.

The vtrq polling period is addressed with an environment variable VELSTOR_VCNC_VTRQ_POLL_PERIOD_SEC.