### PR TITLE
Doughnut not grey even when data is zero

### DIFF
--- a/vcnc-web/src/containers/VtrqVpmReadDoughnut.jsx
+++ b/vcnc-web/src/containers/VtrqVpmReadDoughnut.jsx
@@ -4,9 +4,8 @@ import { connect } from 'react-redux';
 import muiThemeable from 'material-ui/styles/muiThemeable';
 import DoughnutWidget from '../components/widgets/DoughnutWidget';
 
-const readRatesAreZero = data => {
-  return data.reduce((accumulator, item) => accumulator + item, 0 ) === 0;
-};
+const readRatesAreZero = data =>
+  data.reduce((accumulator, item) => accumulator + item, 0) < 1e-6;
 
 const VtrqVpmDoughnut = (props) => {
   //
@@ -16,7 +15,7 @@ const VtrqVpmDoughnut = (props) => {
   //  zero, we make the areas equal size.
 
   const { emptyDoughnutColor, vpmColor, vtrqColor } = props.muiTheme.palette;
-  const doughnutIsEmpty = readRatesAreZero(props.data.datasets[0].data)
+  const doughnutIsEmpty = readRatesAreZero(props.data.datasets[0].data);
   const backgroundColor =
     doughnutIsEmpty
       ? [emptyDoughnutColor, emptyDoughnutColor]


### PR DESCRIPTION
Dave observed that the doughnut was gray initially, but after some activity, when the activity ceased, the doughnut was 50/50 red/blue.  50/50 grey is expected.

This change compares for less than epsilon = 1e-6 rather than exactly zero.  In the future, this will be parameterizable. 