### PR TITLE
Fix <FRQU-238> HTTP code not 404 with ENOENT

### DIFF
--- a/api-python/ChangeLog
+++ b/api-python/ChangeLog
@@ -1,3 +1,7 @@
+Release 3.5.1
+
+    FRQU-238: ENOENT should produce HTTP code 404
+
 Release 3.5.0
 
 	vclc gets a -q / --quiet switch

--- a/api-python/tests/simple/test_sanity.py
+++ b/api-python/tests/simple/test_sanity.py
@@ -77,6 +77,9 @@ def test_ns_copy():
     src_tailname = 'Tjso7JcL0zdz0hI3dBcP'
     srcdir = src_rootname + '/' + src_tailname
     dest_rootname = '/GmqYbvjQkoAEPQIGwzRa'+seed
+    #
+    #  Ensure neither the source nor destination directory exists.
+    #
     try:
         vclc('ns', 'rm', '-r', src_rootname)
     except subprocess.CalledProcessError as e:
@@ -85,6 +88,16 @@ def test_ns_copy():
         vclc('ns', 'rm', '-r', dest_rootname)
     except subprocess.CalledProcessError as e:
         assert(e.returncode == errno.ENOENT)
+    #
+    #  Try to copy non-existent directories.
+    #
+    try:
+        vclc('ns', 'cp', src_rootname, dest_rootname)
+    except subprocess.CalledProcessError as e:
+        assert(e.returncode == errno.ENOENT)
+    #
+    #  Copy directories that exist.  Test all aliases. Expect success.
+    #
     for ns in ('ns', 'namespace'):
         for cmd in ('cp', 'copy'):
             vclc('ns', 'mkdir', '-p', srcdir)

--- a/api-python/tests/simple/test_sanity.py
+++ b/api-python/tests/simple/test_sanity.py
@@ -6,8 +6,8 @@
 #  % PYTHONPATH=. pytest
 import velstor.testlib as testlib
 from velstor.testlib import vclc
+from velstor.testlib import VclcError
 import errno
-import subprocess
 import re
 import json
 import os
@@ -21,35 +21,39 @@ except KeyError:
 
 def test_version():
     vre = '\s*vclc\s+Version\s+\d+\.\d+\.\d+\s+Build\s+\d+'
-    version = vclc('--version')
-    print(version)
-    assert(re.match(vre, version))
+    try:
+        # testlib.vclc assumes that stdout is valid JSON
+        # This is intentionally not the case for --version.
+        vclc('--version')
+        assert False
+    except VclcError as e:
+        version = e.output
+        print(version)
+        assert(re.match(vre, version))
 
 
 def test_ns_ls():
     for ns in ('ns', 'namespace'):
         result = vclc(ns, 'ls', '/')
         print(result)
-        j = json.loads(result)
-        assert(j["http_status"] == 200)
+        assert(result["http_status"] == 200)
 
 
 def test_ns_mk_rm_dir():
     dirname = '/Ime3Wp2uMyaHFLVoNKSf'+seed
     try:
         vclc('ns', 'rm', '-r', dirname)
-    except subprocess.CalledProcessError as e:
+        assert False
+    except VclcError as e:
         assert(e.returncode == errno.ENOENT)
     for ns in ('ns', 'namespace'):
         result = vclc(ns, 'mkdir', dirname)
         print('mkdir result:', result)
-        j = json.loads(result)
-        assert(j['http_status'] == 200)
+        assert(result['http_status'] == 200)
         #
         result = vclc(ns, 'rm', dirname)
         print('rm result:', result)
-        j = json.loads(result)
-        assert(j['http_status'] == 200)
+        assert(result['http_status'] == 200)
 
 
 def test_ns_mk_rm_dir_deep():
@@ -57,19 +61,18 @@ def test_ns_mk_rm_dir_deep():
     dirname = rootname + '/91DWiFjayE0F98BH8tgu/C9VcnHmQ8ZBI4rLXHNge'
     try:
         vclc('ns', 'rm', '-r', rootname)
-    except subprocess.CalledProcessError as e:
+        assert False
+    except VclcError as e:
         assert(e.returncode == errno.ENOENT)
 
     for ns in ('ns', 'namespace'):
         result = vclc(ns, 'mkdir', '-p', dirname)
         print('mkdir result:', result)
-        j = json.loads(result)
-        assert(j['http_status'] == 200)
+        assert(result['http_status'] == 200)
         #
         result = vclc(ns, 'rm', '-r', rootname)
         print('rm result:', result)
-        j = json.loads(result)
-        assert(j['http_status'] == 200)
+        assert(result['http_status'] == 200)
 
 
 def test_ns_copy():
@@ -82,18 +85,21 @@ def test_ns_copy():
     #
     try:
         vclc('ns', 'rm', '-r', src_rootname)
-    except subprocess.CalledProcessError as e:
+        assert False
+    except VclcError as e:
         assert(e.returncode == errno.ENOENT)
     try:
         vclc('ns', 'rm', '-r', dest_rootname)
-    except subprocess.CalledProcessError as e:
+        assert False
+    except VclcError as e:
         assert(e.returncode == errno.ENOENT)
     #
     #  Try to copy non-existent directories.
     #
     try:
-        vclc('ns', 'cp', src_rootname, dest_rootname)
-    except subprocess.CalledProcessError as e:
+        vclc('ns', 'cp', srcdir, dest_rootname)
+        assert False
+    except VclcError as e:
         assert(e.returncode == errno.ENOENT)
     #
     #  Copy directories that exist.  Test all aliases. Expect success.
@@ -103,8 +109,7 @@ def test_ns_copy():
             vclc('ns', 'mkdir', '-p', srcdir)
             result = vclc(ns, cmd, src_rootname, dest_rootname)
             print('ns copy result:', result)
-            j = json.loads(result)
-            assert(j['http_status'] == 200)
+            assert(result['http_status'] == 200)
             #
             vclc('ns', 'rm', '-r', src_rootname)
             vclc('ns', 'rm', '-r', dest_rootname)
@@ -117,16 +122,13 @@ def test_ns_consistency():
             for val in ('immediate', 'eventual'):
                 vclc(ns, 'mkdir', dirname)
                 result = vclc(ns, con, 'set', val, dirname)
-                j = json.loads(result)
-                assert(j['http_status'] == 200)
+                assert(result['http_status'] == 200)
                 #
                 result = vclc(ns, con, 'get', dirname)
                 print(ns, con, 'get', val, ':', result)
-                j = json.loads(result)
-                assert(j['http_status'] == 200)
+                assert(result['http_status'] == 200)
                 result = vclc(ns, 'rm', dirname)
-                j = json.loads(result)
-                assert(j['http_status'] == 200)
+                assert(result['http_status'] == 200)
 
 
 def test_vp_find():
@@ -136,34 +138,33 @@ def test_vp_find():
     try:
         result = vclc('vp', 'find', '--vp_host=scooby', '--mount_point=/doo')
         print('vp find:', result)
-        j = json.loads(result)
-        assert(j['http_status'] == 404)
-    except subprocess.CalledProcessError as e:
+        assert False
+    except VclcError as e:
         print('vp find:', e.output)
-        j = json.loads(e.output.decode('utf-8'))
-        assert(j['http_status'] == 404)
+        assert(e.http_status == 404)
         assert(e.returncode == errno.ENOENT)
 
 
 def test_vp_get():
     try:
         vclc('vp', 'get', '0x0123456789ABCDEF')
-    except subprocess.CalledProcessError as e:
+        assert False
+    except VclcError as e:
         assert(e.returncode == errno.ENOENT)
 
 
 def test_vp_delete():
     try:
         vclc('vp', 'delete', '0x0123456789ABCDEF')
-    except subprocess.CalledProcessError as e:
+        assert False
+    except VclcError as e:
         assert(e.returncode == errno.ENOENT)
 
 
 def test_ws_list():
     result = vclc('ws', 'list', '/')
     print('ws list result:', result)
-    j = json.loads(result)
-    assert(j['http_status'] == 200)
+    assert(result['http_status'] == 200)
     
 
 def test_ws_set_get_delete():
@@ -178,20 +179,17 @@ def test_ws_set_get_delete():
             #  Create a workspace specification
             result = vclc(ws, 'set', root_name, ws_spec)
             print(ws, 'set', result)
-            j = json.loads(result)
-            assert(j['http_status'] == 200)
+            assert(result['http_status'] == 200)
             #
             #  Delete it
             result = vclc(ws, whack, root_name)
             print(ws, whack, result)
-            j = json.loads(result)
-            assert(j['http_status'] == 200)
+            assert(result['http_status'] == 200)
 
 
 def test_grid_list():
     result = vclc('grid', 'list')
-    j = json.loads(result)
-    assert(j['http_status'] == 200)
+    assert(result['http_status'] == 200)
 
 
 def test_grid_lifecycle():
@@ -200,33 +198,28 @@ def test_grid_lifecycle():
     workspace_name = testlib.random_path(5,1)
     workspace_spec = testlib.create_workspace(writeback='never')
     result = vclc('ws', 'set', workspace_name, json.dumps(workspace_spec))
-    j = json.loads(result)
-    assert(j['http_status'] == 200)
+    assert(result['http_status'] == 200)
     #
     #  Post a grid entry
     grid_id = testlib.random_identifier(6)
     result = vclc('grid', 'post', grid_id, workspace_name)
-    j = json.loads(result)
-    assert(j['http_status'] == 200)
+    assert(result['http_status'] == 200)
     #
     #  Look at the grid entry
     result = vclc('grid', 'get', grid_id)
-    j = json.loads(result)
-    assert(j['http_status'] == 200)
+    assert(result['http_status'] == 200)
     #
     #  Delete the grid entry
     result = vclc('grid', 'delete', grid_id)
-    j = json.loads(result)
-    assert(j['http_status'] == 200)
+    assert(result['http_status'] == 200)
     #
     #  Ensure it's gone
     try:
         vclc('grid', 'get', grid_id)
         assert False
-    except subprocess.CalledProcessError as e:
+    except VclcError as e:
         assert(e.returncode == errno.ENOENT)
     #
     #  Delete the workspace
     result = vclc('ws', 'rm', workspace_name)
-    j = json.loads(result)
-    assert(j['http_status'] == 200)
+    assert(result['http_status'] == 200)

--- a/api-python/velstor/api/fulfill202.py
+++ b/api-python/velstor/api/fulfill202.py
@@ -117,7 +117,7 @@ def fulfill202(session, response, interval=10, callback=None):
                 'failed')
         #
         #  ... if the status is 'completed', return the deferred status and
-        #      body as the actual status and bodyp.x
+        #      body as the actual status and body.
         #
         if poll_delivery == 'completed':
             try:
@@ -147,7 +147,7 @@ def fulfill202(session, response, interval=10, callback=None):
                 pass
             continue
         #
-        #  ... Otherwise, the status itself is invalid, which is itxs own
+        #  ... Otherwise, the status itself is invalid, which is its own
         #      sort of EREMOTEIO.
         #
         return _return(

--- a/api-python/velstor/api/namespace.py
+++ b/api-python/velstor/api/namespace.py
@@ -43,7 +43,7 @@ def consistency_set(session, vtrqid, value, path):
         vtrqid (int): ID of the vTRQ.
         value (str): Either 'eventual' or 'immediate'
         path (str): Fully-qualified namespace path.
-
+'
     Returns:
         The return value of :func:`~velstor.api.fulfill202.fulfill202`
     """

--- a/api-python/velstor/api/util.py
+++ b/api-python/velstor/api/util.py
@@ -58,6 +58,7 @@ def synthetic_response(status_code, error_sym, message):
                            'message': message})
     return rtn
 
+
 def rpc_status_to_http_status(error_sym):
     """
     Returns the HTTP status code corresponding to the PIDL RPC status code.

--- a/api-python/velstor/api/util.py
+++ b/api-python/velstor/api/util.py
@@ -6,6 +6,21 @@ import json
 from functools import partial
 print_error = partial(print, file=sys.stderr)
 
+#
+#  Must be kept in sync with vcnc_server/js-extension/src/cncSession.cc
+_http_status = {
+    'OK': 200,
+    'EPERM': 401,
+    'EEXIST': 409,
+    'ENOTDIR': 409,
+    'ENOENT': 404,
+    'EHOSTDOWN': 504,
+    'EINVAL': 400,
+    'ENOTEMPTY': 409,
+    'EPROTO': 500,
+    'EUNATCH': 500,
+}
+
 
 def urlencode(path):
     """URL encodes a string
@@ -21,7 +36,7 @@ def urlencode(path):
     return urllib.parse.quote(path, '')
 
 
-def fake_requests_response(status_code, error_sym, message):
+def synthetic_response(status_code, error_sym, message):
     """
     Returns an object that looks like a 'requests' Response object
 
@@ -42,3 +57,14 @@ def fake_requests_response(status_code, error_sym, message):
     rtn.text = json.dumps({'error_sym': error_sym,
                            'message': message})
     return rtn
+
+def rpc_status_to_http_status(error_sym):
+    """
+    Returns the HTTP status code corresponding to the PIDL RPC status code.
+    
+    :param error_sym: The error code from the vtrq.
+    :return: The corresponding HTTP status code.
+    
+    throws: KeyError
+    """
+    return _http_status[error_sym]

--- a/api-python/velstor/api/workspace.py
+++ b/api-python/velstor/api/workspace.py
@@ -3,7 +3,7 @@
 """
 import requests
 import json
-from velstor.api.util import fake_requests_response as fake_response
+from velstor.api.util import synthetic_response
 from velstor.api.util import urlencode
 from velstor.api.fulfill202 import fulfill202
 
@@ -106,4 +106,4 @@ def set(session, vtrqid, path, spec):
         return fulfill202(session, r)
     except ValueError as e:
         message = 'Invalid workspace specification: ' + str(e)
-        return fake_response(400, 'EINVAL', message)
+        return synthetic_response(400, 'EINVAL', message)

--- a/api-python/velstor/api/workspace_legacy.py
+++ b/api-python/velstor/api/workspace_legacy.py
@@ -3,7 +3,7 @@
 """
 import json
 import copy
-from velstor.api.util import fake_requests_response as fake_response
+from velstor.api.util import synthetic_response
 from velstor.api import workspace as ws
 
 
@@ -96,4 +96,4 @@ def set(session, vtrqid, path, delegation):
             _to_legacy_from_delegation(" ".join(delegation)))
     except ValueError as e:
         message = 'Invalid workspace specification: ' + str(e)
-        return fake_response(400, 'EINVAL', message)
+        return synthetic_response(400, 'EINVAL', message)

--- a/api-python/velstor/testlib.py
+++ b/api-python/velstor/testlib.py
@@ -49,6 +49,10 @@ def vvclc(*args):
     return json.loads(rtn)
 
 
+def vvclcc(*args):
+    """Invokes a vclc command."""
+
+
 def create_workspace(**kwargs):
     """Creates a workspace specification as a Python data structure"""
     vtrq_id = int(kwargs['vtrq_id'] if 'vtrq_id' in kwargs else '0')

--- a/api-python/velstor/vclc/ns_copy.py
+++ b/api-python/velstor/vclc/ns_copy.py
@@ -47,7 +47,7 @@ def ns_copy(session, vtrqid, src, dest, overwrite):
             errsym = payload['result'][0]['error_sym']
         message = os.strerror(reverse_dict_lookup(errno.errorcode, errsym))
         return synthetic_response(
-            rpc_status_to_http_status,
+            rpc_status_to_http_status(errsym),
             errsym,
             message)
     except:

--- a/api-python/velstor/vclc/ns_copy.py
+++ b/api-python/velstor/vclc/ns_copy.py
@@ -3,7 +3,8 @@ import sys
 import os
 import errno
 import json
-from velstor.api.util import fake_requests_response as fake_response
+from velstor.api.util import synthetic_response
+from velstor.api.util import rpc_status_to_http_status
 
 from velstor.vclc.handler import reverse_dict_lookup
 
@@ -45,9 +46,12 @@ def ns_copy(session, vtrqid, src, dest, overwrite):
         if len(payload['result']):
             errsym = payload['result'][0]['error_sym']
         message = os.strerror(reverse_dict_lookup(errno.errorcode, errsym))
-        return fake_response(200, errsym, message)
+        return synthetic_response(
+            rpc_status_to_http_status,
+            errsym,
+            message)
     except:
         message = 'Internal client error on meta-data copy: '
         # message += str(sys.exc_info()[0])
         message += str(sys.exc_info())
-        return fake_response(500, 'EREMOTEIO', message)
+        return synthetic_response(500, 'EREMOTEIO', message)

--- a/api-python/version.json
+++ b/api-python/version.json
@@ -1,5 +1,5 @@
 {
-  "comment": "The vclc version nuber is set here, in this file. The build number is automatically set during the build. Scripts require the four zeros to be literally present."
-  , "version": "3.5.0"
+  "comment": "The vclc version number is set here, in this file. The build number is automatically set during the build. Scripts require the four zeros to be literally present."
+  , "version": "3.5.1"
   , "build": "0000"
 }

--- a/vcnc-server/js-extension/src/cncSession.cc
+++ b/vcnc-server/js-extension/src/cncSession.cc
@@ -78,6 +78,7 @@ namespace cnc {
     // intentionally empty
   }
 
+  // Must be kept in sync with api-python/velstor/api/util.py
   void cncSession::RpcToHttpStatus(const int& rpc_error
                                   , int& http_status_code
                                   , string_type& error_sym


### PR DESCRIPTION
For "economy", the vclc performs a single metadata copy by using the vector metadata copy mechanism.

The python code that forms the adapter between the two has been a constant source of bugs.  FRQU-238 is the latest such.  Typically, it is the V8 code (ccSession.C) that determines how to associate an HTTP error code (like 404) with a UNIX error.h number (like ENOENT).  In this case, where we are deconstructing a vector meta-data response, the association must be done in JavaScript.  This requires either a parallel function in JavaScript, or adding a new JavaScript extension function that uses ccSession.C.  In the interests of time over style, I chose the former.  Comments remind future maintainers that changes must be applied in two places.

**test case upgrades**

While writing the test case for this bug, I took the opportunity to refactor `velstor.api.util.vclc` and its varients into a single function.  The new function return value passes more information back to the caller, enabling deeper and more detailed testing.