### PR TITLE
Fixed bug <B1991> VCNC: Load Transfer Trend graph update gets 'behind…

### DIFF
--- a/vcnc-server/ChangeLog
+++ b/vcnc-server/ChangeLog
@@ -1,3 +1,10 @@
+Release 3.8.6
+
+    Vcnc-sampler:
+    Fixed bug <B1991> VCNC: Load Transfer Trend graph update gets 'behind' the actual data usage
+    Fixed bug with incorrect latency setup
+    rethinkdb begins to get samples after vcnc-sampler has got the first message from vda
+
 Release 3.8.5
 
     Fix to trend graph dropout.

--- a/vcnc-server/config/vcnc-config.yaml
+++ b/vcnc-server/config/vcnc-config.yaml
@@ -66,7 +66,7 @@ vcncSampler:
   period: 5000
   #
   #  The period extension in ms to prevent data loss, ms
-  latency: 35000
+  latency: 30000
   #
   #  The IP address (or hostname) on which to listen for vda posts.
   #  0.0.0.0 listens on all interfaces.

--- a/vcnc-server/configure.ac
+++ b/vcnc-server/configure.ac
@@ -5,7 +5,7 @@
 #
 #	See the file 'COPYING' for license information.
 #
-AC_INIT(vCNC, 3.8.5, nick@icmanage.com)
+AC_INIT(vCNC, 3.8.6, nick@icmanage.com)
 AC_PREFIX_DEFAULT(/opt/vcnc)
 #
 AM_CONFIG_HEADER(config.h)

--- a/vcnc-server/vcnc-sampler/src/lib/rethinkSampler.js
+++ b/vcnc-server/vcnc-sampler/src/lib/rethinkSampler.js
@@ -23,10 +23,12 @@ function feedWatchdog() {
 }
 setInterval(
   () => {
-    if (watchdogFed !== undefined && !watchdogFed) {
+    if (watchdogFed === undefined) return;
+    if (!watchdogFed) {
       console.log('ERROR: No Push() to RethinkDB for at least 1 minute')
+    } else {
+        watchdogFed = false;
     }
-    watchdogFed = false;
   },
   60*1000);
 //  End of watchdog code
@@ -61,8 +63,8 @@ class RethinkdbSampler {
   }
 }
 
-function CreaterethinkdbSampler(p, ltc) {
-  return new RethinkdbSampler(p, ltc);
+function CreaterethinkdbSampler(p) {
+  return new RethinkdbSampler(p);
 }
 
 /**

--- a/vcnc-server/vcnc-sampler/src/lib/vcncSampling.js
+++ b/vcnc-server/vcnc-sampler/src/lib/vcncSampling.js
@@ -22,8 +22,8 @@ const rs = require('./rethinkSampler');
   */
 class VcncSampling {
   constructor(dt, ltc) {
-    this.sampleTime = ((dt !== undefined) ? parseInt(dt, 10) : conf.DefSampleTime());
-    this.latency = (ltc !== undefined) ? parseInt(ltc, 10) : conf.DefLatency(); // ms
+    this.sampleTime = parseInt(dt, 10); // ms
+    this.latency = parseInt(ltc, 10); // ms
     this.msgSampler = vsm.CreateVcncSampler(this.sampleTime, this.latency);
     this.rdb = rs.CreaterethinkdbSampler(this.sampleTime);
     this.msgCount = 0;
@@ -83,6 +83,7 @@ class VcncSampling {
 
   Send() {
     const self = this;
+    if ( self.msgSampler.IsSampling() === false ) return;
     const bin = self.msgSampler.ReleaseBin();
     self.rdb.Push(bin);
   }


### PR DESCRIPTION
    Fixed bug <B1991> VCNC: Load Transfer Trend graph update gets 'behind' the actual data usage
    Fixed bug with incorrect latency setup
    rethinkdb begins to get samples after vcnc-sampler has got the first message from vda
